### PR TITLE
fix linking between README.md and docs/*.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,1036 +47,1036 @@ with elements_sdk.ApiClient(config) as api_client:
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*AIApi* | [**abort_ai_dataset_model_creation**](docs/AIApi#abort_ai_dataset_model_creation) | **POST** `/api/2/ai/models/{id}/abort` | 
-*AIApi* | [**activate_ai_model**](docs/AIApi#activate_ai_model) | **POST** `/api/2/ai/models/{id}/activate` | 
-*AIApi* | [**create_ai_annotation_track**](docs/AIApi#create_ai_annotation_track) | **POST** `/api/2/ai/annotations/tracks/create` | 
-*AIApi* | [**create_ai_category**](docs/AIApi#create_ai_category) | **POST** `/api/2/ai/categories` | 
-*AIApi* | [**create_ai_dataset**](docs/AIApi#create_ai_dataset) | **POST** `/api/2/ai/datasets` | 
-*AIApi* | [**create_ai_dataset_model**](docs/AIApi#create_ai_dataset_model) | **POST** `/api/2/ai/models/create` | 
-*AIApi* | [**create_ai_metadata**](docs/AIApi#create_ai_metadata) | **POST** `/api/2/ai/metadata/create` | 
-*AIApi* | [**create_ai_model**](docs/AIApi#create_ai_model) | **POST** `/api/2/ai/models` | 
-*AIApi* | [**delete_ai_annotation**](docs/AIApi#delete_ai_annotation) | **DELETE** `/api/2/ai/annotations/{id}` | 
-*AIApi* | [**delete_ai_annotation_track**](docs/AIApi#delete_ai_annotation_track) | **DELETE** `/api/2/ai/annotations/tracks/{id}` | 
-*AIApi* | [**delete_ai_category**](docs/AIApi#delete_ai_category) | **DELETE** `/api/2/ai/categories/{id}` | 
-*AIApi* | [**delete_ai_dataset**](docs/AIApi#delete_ai_dataset) | **DELETE** `/api/2/ai/datasets/{id}` | 
-*AIApi* | [**delete_ai_model**](docs/AIApi#delete_ai_model) | **DELETE** `/api/2/ai/models/{id}` | 
-*AIApi* | [**export_ai_dataset**](docs/AIApi#export_ai_dataset) | **POST** `/api/2/ai/datasets/{id}/export` | 
-*AIApi* | [**export_ai_model**](docs/AIApi#export_ai_model) | **POST** `/api/2/ai/models/{id}/export` | 
-*AIApi* | [**get_ai_annotation**](docs/AIApi#get_ai_annotation) | **GET** `/api/2/ai/annotations/{id}` | 
-*AIApi* | [**get_ai_annotation_image**](docs/AIApi#get_ai_annotation_image) | **GET** `/api/2/ai/annotations/{id}/image` | 
-*AIApi* | [**get_ai_category**](docs/AIApi#get_ai_category) | **GET** `/api/2/ai/categories/{id}` | 
-*AIApi* | [**get_ai_connection**](docs/AIApi#get_ai_connection) | **GET** `/api/2/ai/connections/{id}` | 
-*AIApi* | [**get_ai_dataset**](docs/AIApi#get_ai_dataset) | **GET** `/api/2/ai/datasets/{id}` | 
-*AIApi* | [**get_ai_image**](docs/AIApi#get_ai_image) | **GET** `/api/2/ai/images/{id}` | 
-*AIApi* | [**get_ai_image_content**](docs/AIApi#get_ai_image_content) | **GET** `/api/2/ai/images/{id}/content` | 
-*AIApi* | [**get_ai_metadata**](docs/AIApi#get_ai_metadata) | **GET** `/api/2/ai/metadata/{id}` | 
-*AIApi* | [**get_ai_model**](docs/AIApi#get_ai_model) | **GET** `/api/2/ai/models/{id}` | 
-*AIApi* | [**get_all_ai_annotation_tracks**](docs/AIApi#get_all_ai_annotation_tracks) | **GET** `/api/2/ai/annotations/tracks` | 
-*AIApi* | [**get_all_ai_annotations**](docs/AIApi#get_all_ai_annotations) | **GET** `/api/2/ai/annotations` | 
-*AIApi* | [**get_all_ai_categories**](docs/AIApi#get_all_ai_categories) | **GET** `/api/2/ai/categories` | 
-*AIApi* | [**get_all_ai_connections**](docs/AIApi#get_all_ai_connections) | **GET** `/api/2/ai/connections` | 
-*AIApi* | [**get_all_ai_datasets**](docs/AIApi#get_all_ai_datasets) | **GET** `/api/2/ai/datasets` | 
-*AIApi* | [**get_all_ai_images**](docs/AIApi#get_all_ai_images) | **GET** `/api/2/ai/images` | 
-*AIApi* | [**get_all_ai_metadata**](docs/AIApi#get_all_ai_metadata) | **GET** `/api/2/ai/metadata` | 
-*AIApi* | [**get_all_ai_models**](docs/AIApi#get_all_ai_models) | **GET** `/api/2/ai/models` | 
-*AIApi* | [**import_ai_datasets**](docs/AIApi#import_ai_datasets) | **POST** `/api/2/ai/datasets/import` | 
-*AIApi* | [**import_ai_models**](docs/AIApi#import_ai_models) | **POST** `/api/2/ai/datasets/{id}/import-models` | 
-*AIApi* | [**patch_ai_annotation**](docs/AIApi#patch_ai_annotation) | **PATCH** `/api/2/ai/annotations/{id}` | 
-*AIApi* | [**patch_ai_category**](docs/AIApi#patch_ai_category) | **PATCH** `/api/2/ai/categories/{id}` | 
-*AIApi* | [**patch_ai_dataset**](docs/AIApi#patch_ai_dataset) | **PATCH** `/api/2/ai/datasets/{id}` | 
-*AIApi* | [**patch_ai_model**](docs/AIApi#patch_ai_model) | **PATCH** `/api/2/ai/models/{id}` | 
-*AIApi* | [**run_ai_model_inference**](docs/AIApi#run_ai_model_inference) | **POST** `/api/2/ai/models/{id}/inference` | 
-*AIApi* | [**update_ai_annotation**](docs/AIApi#update_ai_annotation) | **PUT** `/api/2/ai/annotations/{id}` | 
-*AIApi* | [**update_ai_category**](docs/AIApi#update_ai_category) | **PUT** `/api/2/ai/categories/{id}` | 
-*AIApi* | [**update_ai_dataset**](docs/AIApi#update_ai_dataset) | **PUT** `/api/2/ai/datasets/{id}` | 
-*AIApi* | [**update_ai_model**](docs/AIApi#update_ai_model) | **PUT** `/api/2/ai/models/{id}` | 
-*AIApi* | [**upload_ai_image**](docs/AIApi#upload_ai_image) | **POST** `/api/2/ai/images/upload` | 
-*AWSApi* | [**create_aws_account**](docs/AWSApi#create_aws_account) | **POST** `/api/2/aws-accounts` | 
-*AWSApi* | [**delete_aws_account**](docs/AWSApi#delete_aws_account) | **DELETE** `/api/2/aws-accounts/{id}` | 
-*AWSApi* | [**get_all_aws_accounts**](docs/AWSApi#get_all_aws_accounts) | **GET** `/api/2/aws-accounts` | 
-*AWSApi* | [**get_aws_account**](docs/AWSApi#get_aws_account) | **GET** `/api/2/aws-accounts/{id}` | 
-*AWSApi* | [**get_aws_account_sns_topics**](docs/AWSApi#get_aws_account_sns_topics) | **GET** `/api/2/aws-accounts/{id}/sns/topics` | 
-*AWSApi* | [**patch_aws_account**](docs/AWSApi#patch_aws_account) | **PATCH** `/api/2/aws-accounts/{id}` | 
-*AWSApi* | [**test_aws_account_credentials**](docs/AWSApi#test_aws_account_credentials) | **POST** `/api/2/aws-accounts/test-credentials` | 
-*AWSApi* | [**update_aws_account**](docs/AWSApi#update_aws_account) | **PUT** `/api/2/aws-accounts/{id}` | 
-*AuthApi* | [**check_auth_ticket**](docs/AuthApi#check_auth_ticket) | **POST** `/api/2/auth/ticket/check` | 
-*AuthApi* | [**create_api_token**](docs/AuthApi#create_api_token) | **POST** `/api/2/api-tokens` | 
-*AuthApi* | [**create_auth_ticket**](docs/AuthApi#create_auth_ticket) | **POST** `/api/2/auth/ticket` | 
-*AuthApi* | [**create_saml_provider**](docs/AuthApi#create_saml_provider) | **POST** `/api/2/auth/saml` | 
-*AuthApi* | [**delete_access_token**](docs/AuthApi#delete_access_token) | **DELETE** `/api/2/auth/access-tokens/{id}` | 
-*AuthApi* | [**delete_api_token**](docs/AuthApi#delete_api_token) | **DELETE** `/api/2/api-tokens/{id}` | 
-*AuthApi* | [**delete_saml_provider**](docs/AuthApi#delete_saml_provider) | **DELETE** `/api/2/auth/saml/{id}` | 
-*AuthApi* | [**generate_password**](docs/AuthApi#generate_password) | **POST** `/api/2/auth/generate-password` | 
-*AuthApi* | [**get_access_token**](docs/AuthApi#get_access_token) | **GET** `/api/2/auth/access-tokens/{id}` | 
-*AuthApi* | [**get_all_access_tokens**](docs/AuthApi#get_all_access_tokens) | **GET** `/api/2/auth/access-tokens` | 
-*AuthApi* | [**get_all_api_tokens**](docs/AuthApi#get_all_api_tokens) | **GET** `/api/2/api-tokens` | 
-*AuthApi* | [**get_all_saml_providers**](docs/AuthApi#get_all_saml_providers) | **GET** `/api/2/auth/saml` | 
-*AuthApi* | [**get_api_token**](docs/AuthApi#get_api_token) | **GET** `/api/2/api-tokens/{id}` | 
-*AuthApi* | [**get_saml_provider**](docs/AuthApi#get_saml_provider) | **GET** `/api/2/auth/saml/{id}` | 
-*AuthApi* | [**get_saml_service_provider_metadata**](docs/AuthApi#get_saml_service_provider_metadata) | **GET** `/api/2/auth/saml/{id}/metadata` | 
-*AuthApi* | [**login**](docs/AuthApi#login) | **POST** `/api/2/auth/login` | 
-*AuthApi* | [**logout**](docs/AuthApi#logout) | **POST** `/api/2/auth/logout` | 
-*AuthApi* | [**logout_page**](docs/AuthApi#logout_page) | **GET** `/api/2/auth/logout` | 
-*AuthApi* | [**parse_samlidp_metadata**](docs/AuthApi#parse_samlidp_metadata) | **POST** `/api/2/auth/saml/parse-idp-metadata` | 
-*AuthApi* | [**patch_api_token**](docs/AuthApi#patch_api_token) | **PATCH** `/api/2/api-tokens/{id}` | 
-*AuthApi* | [**patch_saml_provider**](docs/AuthApi#patch_saml_provider) | **PATCH** `/api/2/auth/saml/{id}` | 
-*AuthApi* | [**receive_saml_auth_assertion**](docs/AuthApi#receive_saml_auth_assertion) | **POST** `/api/2/auth/saml/{id}/assertion` | 
-*AuthApi* | [**refresh_samlidp_metadata**](docs/AuthApi#refresh_samlidp_metadata) | **POST** `/api/2/auth/saml/{id}/refresh-idp-metadata` | 
-*AuthApi* | [**reset_password**](docs/AuthApi#reset_password) | **POST** `/api/2/auth/reset-password` | 
-*AuthApi* | [**return_from_saml_auth**](docs/AuthApi#return_from_saml_auth) | **GET** `/api/2/auth/saml/{id}/sso/return` | 
-*AuthApi* | [**return_from_saml_logout**](docs/AuthApi#return_from_saml_logout) | **GET** `/api/2/auth/saml/{id}/sls/return` | 
-*AuthApi* | [**send_access_token_email_notification**](docs/AuthApi#send_access_token_email_notification) | **POST** `/api/2/auth/access-tokens/{id}/email` | 
-*AuthApi* | [**start_impersonation**](docs/AuthApi#start_impersonation) | **POST** `/api/2/auth/impersonation` | 
-*AuthApi* | [**start_saml_auth**](docs/AuthApi#start_saml_auth) | **GET** `/api/2/auth/saml/{id}/sso` | 
-*AuthApi* | [**start_saml_logout**](docs/AuthApi#start_saml_logout) | **GET** `/api/2/auth/saml/{id}/sls` | 
-*AuthApi* | [**stop_impersonation**](docs/AuthApi#stop_impersonation) | **POST** `/api/2/auth/impersonation/stop` | 
-*AuthApi* | [**update_api_token**](docs/AuthApi#update_api_token) | **PUT** `/api/2/api-tokens/{id}` | 
-*AuthApi* | [**update_saml_provider**](docs/AuthApi#update_saml_provider) | **PUT** `/api/2/auth/saml/{id}` | 
-*AutomationApi* | [**abort_task**](docs/AutomationApi#abort_task) | **POST** `/api/2/tasks/{id}/abort` | 
-*AutomationApi* | [**create_job**](docs/AutomationApi#create_job) | **POST** `/api/2/jobs` | 
-*AutomationApi* | [**create_schedule**](docs/AutomationApi#create_schedule) | **POST** `/api/2/schedules` | 
-*AutomationApi* | [**create_subtask**](docs/AutomationApi#create_subtask) | **POST** `/api/2/subtasks` | 
-*AutomationApi* | [**delete_finished_tasks**](docs/AutomationApi#delete_finished_tasks) | **DELETE** `/api/2/tasks/finished` | 
-*AutomationApi* | [**delete_job**](docs/AutomationApi#delete_job) | **DELETE** `/api/2/jobs/{id}` | 
-*AutomationApi* | [**delete_schedule**](docs/AutomationApi#delete_schedule) | **DELETE** `/api/2/schedules/{id}` | 
-*AutomationApi* | [**delete_subtask**](docs/AutomationApi#delete_subtask) | **DELETE** `/api/2/subtasks/{id}` | 
-*AutomationApi* | [**delete_task**](docs/AutomationApi#delete_task) | **DELETE** `/api/2/tasks/{id}` | 
-*AutomationApi* | [**download_all_task_logs**](docs/AutomationApi#download_all_task_logs) | **GET** `/api/2/tasks/logs/download` | 
-*AutomationApi* | [**download_task_log**](docs/AutomationApi#download_task_log) | **GET** `/api/2/tasks/{id}/log/download` | 
-*AutomationApi* | [**export_job**](docs/AutomationApi#export_job) | **GET** `/api/2/jobs/{id}/export` | 
-*AutomationApi* | [**get_all_events**](docs/AutomationApi#get_all_events) | **GET** `/api/2/events` | 
-*AutomationApi* | [**get_all_jobs**](docs/AutomationApi#get_all_jobs) | **GET** `/api/2/jobs` | 
-*AutomationApi* | [**get_all_schedules**](docs/AutomationApi#get_all_schedules) | **GET** `/api/2/schedules` | 
-*AutomationApi* | [**get_all_subtasks**](docs/AutomationApi#get_all_subtasks) | **GET** `/api/2/subtasks` | 
-*AutomationApi* | [**get_all_task_queues**](docs/AutomationApi#get_all_task_queues) | **GET** `/api/2/tasks/queues` | 
-*AutomationApi* | [**get_all_task_types**](docs/AutomationApi#get_all_task_types) | **GET** `/api/2/tasks/types` | 
-*AutomationApi* | [**get_all_tasks**](docs/AutomationApi#get_all_tasks) | **GET** `/api/2/tasks` | 
-*AutomationApi* | [**get_event**](docs/AutomationApi#get_event) | **GET** `/api/2/events/{id}` | 
-*AutomationApi* | [**get_finished_tasks**](docs/AutomationApi#get_finished_tasks) | **GET** `/api/2/tasks/finished` | 
-*AutomationApi* | [**get_job**](docs/AutomationApi#get_job) | **GET** `/api/2/jobs/{id}` | 
-*AutomationApi* | [**get_pending_tasks**](docs/AutomationApi#get_pending_tasks) | **GET** `/api/2/tasks/pending` | 
-*AutomationApi* | [**get_python_environments**](docs/AutomationApi#get_python_environments) | **GET** `/api/2/python/environments` | 
-*AutomationApi* | [**get_schedule**](docs/AutomationApi#get_schedule) | **GET** `/api/2/schedules/{id}` | 
-*AutomationApi* | [**get_subtask**](docs/AutomationApi#get_subtask) | **GET** `/api/2/subtasks/{id}` | 
-*AutomationApi* | [**get_task**](docs/AutomationApi#get_task) | **GET** `/api/2/tasks/{id}` | 
-*AutomationApi* | [**get_task_log**](docs/AutomationApi#get_task_log) | **GET** `/api/2/tasks/{id}/log` | 
-*AutomationApi* | [**get_task_type**](docs/AutomationApi#get_task_type) | **GET** `/api/2/tasks/types/{type}` | 
-*AutomationApi* | [**get_tasks_summary**](docs/AutomationApi#get_tasks_summary) | **GET** `/api/2/tasks/summary` | 
-*AutomationApi* | [**import_job**](docs/AutomationApi#import_job) | **POST** `/api/2/jobs/import` | 
-*AutomationApi* | [**kill_all_pending_tasks**](docs/AutomationApi#kill_all_pending_tasks) | **DELETE** `/api/2/tasks/pending` | 
-*AutomationApi* | [**kill_task**](docs/AutomationApi#kill_task) | **POST** `/api/2/tasks/{id}/kill` | 
-*AutomationApi* | [**patch_job**](docs/AutomationApi#patch_job) | **PATCH** `/api/2/jobs/{id}` | 
-*AutomationApi* | [**patch_schedule**](docs/AutomationApi#patch_schedule) | **PATCH** `/api/2/schedules/{id}` | 
-*AutomationApi* | [**patch_subtask**](docs/AutomationApi#patch_subtask) | **PATCH** `/api/2/subtasks/{id}` | 
-*AutomationApi* | [**restart_task**](docs/AutomationApi#restart_task) | **POST** `/api/2/tasks/{id}/restart` | 
-*AutomationApi* | [**start_job**](docs/AutomationApi#start_job) | **POST** `/api/2/jobs/{id}/start` | 
-*AutomationApi* | [**start_task**](docs/AutomationApi#start_task) | **POST** `/api/2/tasks/start` | 
-*AutomationApi* | [**update_job**](docs/AutomationApi#update_job) | **PUT** `/api/2/jobs/{id}` | 
-*AutomationApi* | [**update_schedule**](docs/AutomationApi#update_schedule) | **PUT** `/api/2/schedules/{id}` | 
-*AutomationApi* | [**update_subtask**](docs/AutomationApi#update_subtask) | **PUT** `/api/2/subtasks/{id}` | 
-*ClickApi* | [**abort_click_upload**](docs/ClickApi#abort_click_upload) | **DELETE** `/api/2/click/uploads/{upload_id}` | 
-*ClickApi* | [**add_assets_to_click_gallery**](docs/ClickApi#add_assets_to_click_gallery) | **POST** `/api/2/click/connections/{connection_id}/galleries/{id}/add-assets` | 
-*ClickApi* | [**continue_click_upload_in_background**](docs/ClickApi#continue_click_upload_in_background) | **POST** `/api/2/click/uploads/{upload_id}/background` | 
-*ClickApi* | [**create_click_gallery**](docs/ClickApi#create_click_gallery) | **POST** `/api/2/click/connections/{connection_id}/galleries` | 
-*ClickApi* | [**create_click_gallery_link**](docs/ClickApi#create_click_gallery_link) | **POST** `/api/2/click/connections/{connection_id}/gallery-links` | 
-*ClickApi* | [**delete_click_gallery_link**](docs/ClickApi#delete_click_gallery_link) | **DELETE** `/api/2/click/connections/{connection_id}/gallery-links/{id}` | 
-*ClickApi* | [**get_all_click_galleries**](docs/ClickApi#get_all_click_galleries) | **GET** `/api/2/click/connections/{connection_id}/galleries` | 
-*ClickApi* | [**get_all_click_gallery_links**](docs/ClickApi#get_all_click_gallery_links) | **GET** `/api/2/click/connections/{connection_id}/gallery-links` | 
-*ClickApi* | [**get_click_gallery**](docs/ClickApi#get_click_gallery) | **GET** `/api/2/click/connections/{connection_id}/galleries/{id}` | 
-*ClickApi* | [**get_click_gallery_link**](docs/ClickApi#get_click_gallery_link) | **GET** `/api/2/click/connections/{connection_id}/gallery-links/{id}` | 
-*ClickApi* | [**send_click_gallery_link_email**](docs/ClickApi#send_click_gallery_link_email) | **POST** `/api/2/click/connections/{connection_id}/gallery-links/{link_id}/send` | 
-*ClickApi* | [**start_click_upload**](docs/ClickApi#start_click_upload) | **POST** `/api/2/click/uploads` | 
-*IntegrationsApi* | [**delete_slack_connection**](docs/IntegrationsApi#delete_slack_connection) | **DELETE** `/api/2/integrations/slack/{id}` | 
-*IntegrationsApi* | [**delete_teams_connection**](docs/IntegrationsApi#delete_teams_connection) | **DELETE** `/api/2/integrations/teams/{id}` | 
-*IntegrationsApi* | [**get_all_slack_connections**](docs/IntegrationsApi#get_all_slack_connections) | **GET** `/api/2/integrations/slack` | 
-*IntegrationsApi* | [**get_all_teams_connections**](docs/IntegrationsApi#get_all_teams_connections) | **GET** `/api/2/integrations/teams` | 
-*IntegrationsApi* | [**get_slack_channels**](docs/IntegrationsApi#get_slack_channels) | **GET** `/api/2/integrations/slack/{id}/channels` | 
-*IntegrationsApi* | [**get_slack_connection**](docs/IntegrationsApi#get_slack_connection) | **GET** `/api/2/integrations/slack/{id}` | 
-*IntegrationsApi* | [**get_slack_emoji**](docs/IntegrationsApi#get_slack_emoji) | **GET** `/api/2/integrations/slack/{id}/emoji` | 
-*IntegrationsApi* | [**get_slack_users**](docs/IntegrationsApi#get_slack_users) | **GET** `/api/2/integrations/slack/{id}/users` | 
-*IntegrationsApi* | [**get_teams_channels**](docs/IntegrationsApi#get_teams_channels) | **GET** `/api/2/integrations/teams/{id}/channels` | 
-*IntegrationsApi* | [**get_teams_connection**](docs/IntegrationsApi#get_teams_connection) | **GET** `/api/2/integrations/teams/{id}` | 
-*IntegrationsApi* | [**get_teams_users**](docs/IntegrationsApi#get_teams_users) | **GET** `/api/2/integrations/teams/{id}/users` | 
-*IntegrationsApi* | [**patch_slack_connection**](docs/IntegrationsApi#patch_slack_connection) | **PATCH** `/api/2/integrations/slack/{id}` | 
-*IntegrationsApi* | [**patch_teams_connection**](docs/IntegrationsApi#patch_teams_connection) | **PATCH** `/api/2/integrations/teams/{id}` | 
-*IntegrationsApi* | [**send_slack_message**](docs/IntegrationsApi#send_slack_message) | **POST** `/api/2/integrations/slack/{id}/message` | 
-*IntegrationsApi* | [**send_teams_message**](docs/IntegrationsApi#send_teams_message) | **POST** `/api/2/integrations/teams/{id}/send-message` | 
-*IntegrationsApi* | [**start_slack_connection_flow**](docs/IntegrationsApi#start_slack_connection_flow) | **GET** `/api/2/integrations/slack/connect` | 
-*IntegrationsApi* | [**start_slack_connection_token_refresh_flow**](docs/IntegrationsApi#start_slack_connection_token_refresh_flow) | **GET** `/api/2/integrations/slack/{id}/refresh-token` | 
-*IntegrationsApi* | [**start_teams_connection_flow**](docs/IntegrationsApi#start_teams_connection_flow) | **GET** `/api/2/integrations/teams/connect` | 
-*IntegrationsApi* | [**start_teams_connection_token_refresh_flow**](docs/IntegrationsApi#start_teams_connection_token_refresh_flow) | **GET** `/api/2/integrations/teams/{id}/refresh-token` | 
-*IntegrationsApi* | [**update_slack_connection**](docs/IntegrationsApi#update_slack_connection) | **PUT** `/api/2/integrations/slack/{id}` | 
-*IntegrationsApi* | [**update_teams_connection**](docs/IntegrationsApi#update_teams_connection) | **PUT** `/api/2/integrations/teams/{id}` | 
-*MainApi* | [**apply_configuration**](docs/MainApi#apply_configuration) | **POST** `/api/2/configuration/apply` | 
-*MainApi* | [**beep**](docs/MainApi#beep) | **POST** `/api/2/system/beep` | 
-*MainApi* | [**check_certificate**](docs/MainApi#check_certificate) | **POST** `/api/2/system/certificate/check` | 
-*MainApi* | [**check_chunk_uploaded**](docs/MainApi#check_chunk_uploaded) | **GET** `/api/2/uploads/chunk` | 
-*MainApi* | [**check_internet_connectivity**](docs/MainApi#check_internet_connectivity) | **POST** `/api/2/system/check-connectivity` | 
-*MainApi* | [**check_stor_next_license**](docs/MainApi#check_stor_next_license) | **POST** `/api/2/stornext-license/check` | 
-*MainApi* | [**collect_diagnostics**](docs/MainApi#collect_diagnostics) | **POST** `/api/2/system/collect-diagnostics` | 
-*MainApi* | [**create_archive**](docs/MainApi#create_archive) | **POST** `/api/2/download-archive/create` | 
-*MainApi* | [**create_cloud_account**](docs/MainApi#create_cloud_account) | **POST** `/api/2/cloud/accounts` | 
-*MainApi* | [**create_filesystem_permission**](docs/MainApi#create_filesystem_permission) | **POST** `/api/2/filesystem-permissions` | 
-*MainApi* | [**create_group**](docs/MainApi#create_group) | **POST** `/api/2/groups` | 
-*MainApi* | [**create_home_workspace**](docs/MainApi#create_home_workspace) | **POST** `/api/2/users/{id}/home` | 
-*MainApi* | [**create_ntp_server**](docs/MainApi#create_ntp_server) | **POST** `/api/2/system/time/servers` | 
-*MainApi* | [**create_user**](docs/MainApi#create_user) | **POST** `/api/2/users` | 
-*MainApi* | [**create_workstation**](docs/MainApi#create_workstation) | **POST** `/api/2/workstations` | 
-*MainApi* | [**delete_cloud_account**](docs/MainApi#delete_cloud_account) | **DELETE** `/api/2/cloud/accounts/{id}` | 
-*MainApi* | [**delete_download_archive**](docs/MainApi#delete_download_archive) | **DELETE** `/api/2/download-archive/{id}` | 
-*MainApi* | [**delete_filesystem_permission**](docs/MainApi#delete_filesystem_permission) | **DELETE** `/api/2/filesystem-permissions/{id}` | 
-*MainApi* | [**delete_group**](docs/MainApi#delete_group) | **DELETE** `/api/2/groups/{id}` | 
-*MainApi* | [**delete_home_workspace**](docs/MainApi#delete_home_workspace) | **DELETE** `/api/2/users/{id}/home` | 
-*MainApi* | [**delete_ntp_server**](docs/MainApi#delete_ntp_server) | **DELETE** `/api/2/system/time/servers/{id}` | 
-*MainApi* | [**delete_user**](docs/MainApi#delete_user) | **DELETE** `/api/2/users/{id}` | 
-*MainApi* | [**delete_workstation**](docs/MainApi#delete_workstation) | **DELETE** `/api/2/workstations/{id}` | 
-*MainApi* | [**disable_user_totp**](docs/MainApi#disable_user_totp) | **DELETE** `/api/2/users/{id}/totp` | 
-*MainApi* | [**enable_user_totp**](docs/MainApi#enable_user_totp) | **POST** `/api/2/users/{id}/totp` | 
-*MainApi* | [**finish_upload**](docs/MainApi#finish_upload) | **POST** `/api/2/uploads/finish` | 
-*MainApi* | [**fix_ldap_group_memberships**](docs/MainApi#fix_ldap_group_memberships) | **POST** `/api/2/ldap-servers/{id}/fix-memberships` | 
-*MainApi* | [**get_all_client_sessions**](docs/MainApi#get_all_client_sessions) | **GET** `/api/2/client-sessions` | 
-*MainApi* | [**get_all_cloud_accounts**](docs/MainApi#get_all_cloud_accounts) | **GET** `/api/2/cloud/accounts` | 
-*MainApi* | [**get_all_download_archives**](docs/MainApi#get_all_download_archives) | **GET** `/api/2/download-archive` | 
-*MainApi* | [**get_all_downloads**](docs/MainApi#get_all_downloads) | **GET** `/api/2/downloads` | 
-*MainApi* | [**get_all_filesystem_permissions**](docs/MainApi#get_all_filesystem_permissions) | **GET** `/api/2/filesystem-permissions` | 
-*MainApi* | [**get_all_groups**](docs/MainApi#get_all_groups) | **GET** `/api/2/groups` | 
-*MainApi* | [**get_all_ldap_servers**](docs/MainApi#get_all_ldap_servers) | **GET** `/api/2/ldap-servers` | 
-*MainApi* | [**get_all_ntp_servers**](docs/MainApi#get_all_ntp_servers) | **GET** `/api/2/system/time/servers` | 
-*MainApi* | [**get_all_storage_nodes**](docs/MainApi#get_all_storage_nodes) | **GET** `/api/2/nodes` | 
-*MainApi* | [**get_all_users**](docs/MainApi#get_all_users) | **GET** `/api/2/users` | 
-*MainApi* | [**get_all_workstations**](docs/MainApi#get_all_workstations) | **GET** `/api/2/workstations` | 
-*MainApi* | [**get_certificate_configuration**](docs/MainApi#get_certificate_configuration) | **GET** `/api/2/system/certificate` | 
-*MainApi* | [**get_client_download_file**](docs/MainApi#get_client_download_file) | **GET** `/api/2/downloads/clients/{file}` | 
-*MainApi* | [**get_client_downloads**](docs/MainApi#get_client_downloads) | **GET** `/api/2/downloads/clients` | 
-*MainApi* | [**get_client_session**](docs/MainApi#get_client_session) | **GET** `/api/2/client-sessions/{id}` | 
-*MainApi* | [**get_cloud_account**](docs/MainApi#get_cloud_account) | **GET** `/api/2/cloud/accounts/{id}` | 
-*MainApi* | [**get_cloud_account_storage_roots**](docs/MainApi#get_cloud_account_storage_roots) | **GET** `/api/2/cloud/accounts/{id}/storage-roots` | 
-*MainApi* | [**get_current_workstation**](docs/MainApi#get_current_workstation) | **GET** `/api/2/workstations/current` | 
-*MainApi* | [**get_download**](docs/MainApi#get_download) | **GET** `/api/2/downloads/{id}` | 
-*MainApi* | [**get_download_archive**](docs/MainApi#get_download_archive) | **GET** `/api/2/download-archive/{id}` | 
-*MainApi* | [**get_download_archive_file**](docs/MainApi#get_download_archive_file) | **GET** `/api/2/download-archive/{id}/download` | 
-*MainApi* | [**get_download_file**](docs/MainApi#get_download_file) | **GET** `/api/2/downloads/{id}/download` | 
-*MainApi* | [**get_download_icon**](docs/MainApi#get_download_icon) | **GET** `/api/2/downloads/{id}/icon` | 
-*MainApi* | [**get_filesystem_permission**](docs/MainApi#get_filesystem_permission) | **GET** `/api/2/filesystem-permissions/{id}` | 
-*MainApi* | [**get_group**](docs/MainApi#get_group) | **GET** `/api/2/groups/{id}` | 
-*MainApi* | [**get_home_workspace**](docs/MainApi#get_home_workspace) | **GET** `/api/2/users/{id}/home` | 
-*MainApi* | [**get_ipmi_configuration**](docs/MainApi#get_ipmi_configuration) | **GET** `/api/2/nodes/{id}/ipmi` | 
-*MainApi* | [**get_ldap_server**](docs/MainApi#get_ldap_server) | **GET** `/api/2/ldap-servers/{id}` | 
-*MainApi* | [**get_ldap_server_groups**](docs/MainApi#get_ldap_server_groups) | **GET** `/api/2/ldap-servers/{id}/groups` | 
-*MainApi* | [**get_ldap_server_users**](docs/MainApi#get_ldap_server_users) | **GET** `/api/2/ldap-servers/{id}/users` | 
-*MainApi* | [**get_license**](docs/MainApi#get_license) | **GET** `/api/2/license` | 
-*MainApi* | [**get_local_time**](docs/MainApi#get_local_time) | **GET** `/api/2/system/time` | 
-*MainApi* | [**get_log**](docs/MainApi#get_log) | **GET** `/api/2/system/log/{path}` | 
-*MainApi* | [**get_node_ipmi_sensors**](docs/MainApi#get_node_ipmi_sensors) | **GET** `/api/2/nodes/{id}/sensors` | 
-*MainApi* | [**get_node_stats**](docs/MainApi#get_node_stats) | **GET** `/api/2/nodes/{id}/stats` | 
-*MainApi* | [**get_ntp_server**](docs/MainApi#get_ntp_server) | **GET** `/api/2/system/time/servers/{id}` | 
-*MainApi* | [**get_parameters**](docs/MainApi#get_parameters) | **GET** `/api/2/parameters` | 
-*MainApi* | [**get_profile**](docs/MainApi#get_profile) | **GET** `/api/2/users/me` | 
-*MainApi* | [**get_release_notes**](docs/MainApi#get_release_notes) | **GET** `/api/2/release-notes` | 
-*MainApi* | [**get_service_status**](docs/MainApi#get_service_status) | **GET** `/api/2/nodes/{id}/services/{service}` | 
-*MainApi* | [**get_smtp_configuration**](docs/MainApi#get_smtp_configuration) | **GET** `/api/2/system/smtp` | 
-*MainApi* | [**get_stor_next_license**](docs/MainApi#get_stor_next_license) | **GET** `/api/2/stornext-license` | 
-*MainApi* | [**get_storage_node**](docs/MainApi#get_storage_node) | **GET** `/api/2/nodes/{id}` | 
-*MainApi* | [**get_system_info**](docs/MainApi#get_system_info) | **GET** `/api/2/system/info` | 
-*MainApi* | [**get_user**](docs/MainApi#get_user) | **GET** `/api/2/users/{id}` | 
-*MainApi* | [**get_workstation**](docs/MainApi#get_workstation) | **GET** `/api/2/workstations/{id}` | 
-*MainApi* | [**install_stor_next_license**](docs/MainApi#install_stor_next_license) | **POST** `/api/2/stornext-license` | 
-*MainApi* | [**patch_cloud_account**](docs/MainApi#patch_cloud_account) | **PATCH** `/api/2/cloud/accounts/{id}` | 
-*MainApi* | [**patch_current_workstation**](docs/MainApi#patch_current_workstation) | **PATCH** `/api/2/workstations/current` | 
-*MainApi* | [**patch_download_archive**](docs/MainApi#patch_download_archive) | **PATCH** `/api/2/download-archive/{id}` | 
-*MainApi* | [**patch_filesystem_permission**](docs/MainApi#patch_filesystem_permission) | **PATCH** `/api/2/filesystem-permissions/{id}` | 
-*MainApi* | [**patch_group**](docs/MainApi#patch_group) | **PATCH** `/api/2/groups/{id}` | 
-*MainApi* | [**patch_ntp_server**](docs/MainApi#patch_ntp_server) | **PATCH** `/api/2/system/time/servers/{id}` | 
-*MainApi* | [**patch_profile**](docs/MainApi#patch_profile) | **PATCH** `/api/2/users/me` | 
-*MainApi* | [**patch_user**](docs/MainApi#patch_user) | **PATCH** `/api/2/users/{id}` | 
-*MainApi* | [**patch_workstation**](docs/MainApi#patch_workstation) | **PATCH** `/api/2/workstations/{id}` | 
-*MainApi* | [**preview_user**](docs/MainApi#preview_user) | **POST** `/api/2/users/preview` | 
-*MainApi* | [**reboot**](docs/MainApi#reboot) | **POST** `/api/2/system/reboot` | 
-*MainApi* | [**register_upload**](docs/MainApi#register_upload) | **POST** `/api/2/uploads/register` | 
-*MainApi* | [**register_upload_metadata**](docs/MainApi#register_upload_metadata) | **POST** `/api/2/uploads/metadata` | 
-*MainApi* | [**render_email_template_preview**](docs/MainApi#render_email_template_preview) | **POST** `/api/2/system/smtp/preview` | 
-*MainApi* | [**reset_user_password**](docs/MainApi#reset_user_password) | **POST** `/api/2/users/{id}/password/reset` | 
-*MainApi* | [**restart_web_ui**](docs/MainApi#restart_web_ui) | **POST** `/api/2/system/restart-webui` | 
-*MainApi* | [**run_service_operation**](docs/MainApi#run_service_operation) | **POST** `/api/2/nodes/{id}/services/{service}/{operation}` | 
-*MainApi* | [**set_ipmi_configuration**](docs/MainApi#set_ipmi_configuration) | **PUT** `/api/2/nodes/{id}/ipmi` | 
-*MainApi* | [**set_local_time**](docs/MainApi#set_local_time) | **POST** `/api/2/system/time` | 
-*MainApi* | [**set_my_password**](docs/MainApi#set_my_password) | **POST** `/api/2/users/me/password` | 
-*MainApi* | [**set_user_password**](docs/MainApi#set_user_password) | **POST** `/api/2/users/{id}/password` | 
-*MainApi* | [**shutdown**](docs/MainApi#shutdown) | **POST** `/api/2/system/shutdown` | 
-*MainApi* | [**start_solr_reindex**](docs/MainApi#start_solr_reindex) | **POST** `/api/2/system/solr/reindex` | 
-*MainApi* | [**start_support_session**](docs/MainApi#start_support_session) | **POST** `/api/2/system/support-session/start` | 
-*MainApi* | [**start_system_backup**](docs/MainApi#start_system_backup) | **POST** `/api/2/system/backup/start` | 
-*MainApi* | [**sync_ldap_group**](docs/MainApi#sync_ldap_group) | **POST** `/api/2/groups/{id}/ldap-sync` | 
-*MainApi* | [**sync_ldap_users**](docs/MainApi#sync_ldap_users) | **POST** `/api/2/ldap-servers/{id}/sync-users` | 
-*MainApi* | [**sync_time**](docs/MainApi#sync_time) | **POST** `/api/2/system/time/sync` | 
-*MainApi* | [**sync_user_totp**](docs/MainApi#sync_user_totp) | **PUT** `/api/2/users/{id}/totp` | 
-*MainApi* | [**test_cloud_account_credentials**](docs/MainApi#test_cloud_account_credentials) | **POST** `/api/2/cloud/accounts/test-credentials` | 
-*MainApi* | [**test_smtp_configuration**](docs/MainApi#test_smtp_configuration) | **POST** `/api/2/system/smtp/test` | 
-*MainApi* | [**update_certificate_configuration**](docs/MainApi#update_certificate_configuration) | **PUT** `/api/2/system/certificate` | 
-*MainApi* | [**update_cloud_account**](docs/MainApi#update_cloud_account) | **PUT** `/api/2/cloud/accounts/{id}` | 
-*MainApi* | [**update_current_workstation**](docs/MainApi#update_current_workstation) | **PUT** `/api/2/workstations/current` | 
-*MainApi* | [**update_download_archive**](docs/MainApi#update_download_archive) | **PUT** `/api/2/download-archive/{id}` | 
-*MainApi* | [**update_filesystem_permission**](docs/MainApi#update_filesystem_permission) | **PUT** `/api/2/filesystem-permissions/{id}` | 
-*MainApi* | [**update_group**](docs/MainApi#update_group) | **PUT** `/api/2/groups/{id}` | 
-*MainApi* | [**update_ntp_server**](docs/MainApi#update_ntp_server) | **PUT** `/api/2/system/time/servers/{id}` | 
-*MainApi* | [**update_parameters**](docs/MainApi#update_parameters) | **PUT** `/api/2/parameters` | 
-*MainApi* | [**update_profile**](docs/MainApi#update_profile) | **PUT** `/api/2/users/me` | 
-*MainApi* | [**update_smtp_configuration**](docs/MainApi#update_smtp_configuration) | **PUT** `/api/2/system/smtp` | 
-*MainApi* | [**update_user**](docs/MainApi#update_user) | **PUT** `/api/2/users/{id}` | 
-*MainApi* | [**update_workstation**](docs/MainApi#update_workstation) | **PUT** `/api/2/workstations/{id}` | 
-*MainApi* | [**upload_chunk**](docs/MainApi#upload_chunk) | **POST** `/api/2/uploads/chunk` | 
-*MediaLibraryApi* | [**bookmark_media_directory**](docs/MediaLibraryApi#bookmark_media_directory) | **POST** `/api/2/media/files/{id}/bookmark` | 
-*MediaLibraryApi* | [**clear_subclip_clipboard**](docs/MediaLibraryApi#clear_subclip_clipboard) | **DELETE** `/api/2/media/subclips/clipboard/clear` | 
-*MediaLibraryApi* | [**clear_subtitle_clipboard**](docs/MediaLibraryApi#clear_subtitle_clipboard) | **DELETE** `/api/2/media/subtitles/clipboard/clear` | 
-*MediaLibraryApi* | [**combine_assets_into_set**](docs/MediaLibraryApi#combine_assets_into_set) | **POST** `/api/2/media/assets/combine` | 
-*MediaLibraryApi* | [**create_asset**](docs/MediaLibraryApi#create_asset) | **POST** `/api/2/media/assets` | 
-*MediaLibraryApi* | [**create_asset_rating**](docs/MediaLibraryApi#create_asset_rating) | **POST** `/api/2/media/ratings` | 
-*MediaLibraryApi* | [**create_asset_subtitle_link**](docs/MediaLibraryApi#create_asset_subtitle_link) | **POST** `/api/2/media/assets/subtitle-links` | 
-*MediaLibraryApi* | [**create_comment**](docs/MediaLibraryApi#create_comment) | **POST** `/api/2/media/comments` | 
-*MediaLibraryApi* | [**create_custom_field**](docs/MediaLibraryApi#create_custom_field) | **POST** `/api/2/media/custom-fields` | 
-*MediaLibraryApi* | [**create_editor_project**](docs/MediaLibraryApi#create_editor_project) | **POST** `/api/2/media/editor` | 
-*MediaLibraryApi* | [**create_editor_subtitle**](docs/MediaLibraryApi#create_editor_subtitle) | **POST** `/api/2/media/subtitles` | 
-*MediaLibraryApi* | [**create_external_transcoder**](docs/MediaLibraryApi#create_external_transcoder) | **POST** `/api/2/media/external-transcoders` | 
-*MediaLibraryApi* | [**create_marker**](docs/MediaLibraryApi#create_marker) | **POST** `/api/2/media/markers` | 
-*MediaLibraryApi* | [**create_media_file_template**](docs/MediaLibraryApi#create_media_file_template) | **POST** `/api/2/media/files/templates` | 
-*MediaLibraryApi* | [**create_media_root**](docs/MediaLibraryApi#create_media_root) | **POST** `/api/2/media/roots` | 
-*MediaLibraryApi* | [**create_media_root_permission**](docs/MediaLibraryApi#create_media_root_permission) | **POST** `/api/2/media/root-permissions` | 
-*MediaLibraryApi* | [**create_media_tag**](docs/MediaLibraryApi#create_media_tag) | **POST** `/api/2/media/tags` | 
-*MediaLibraryApi* | [**create_proxy_profile**](docs/MediaLibraryApi#create_proxy_profile) | **POST** `/api/2/media/proxy-profiles` | 
-*MediaLibraryApi* | [**create_saved_search**](docs/MediaLibraryApi#create_saved_search) | **POST** `/api/2/media/saved-searches` | 
-*MediaLibraryApi* | [**create_subclip**](docs/MediaLibraryApi#create_subclip) | **POST** `/api/2/media/subclips` | 
-*MediaLibraryApi* | [**create_subclip_clipboard_entry**](docs/MediaLibraryApi#create_subclip_clipboard_entry) | **POST** `/api/2/media/subclips/clipboard` | 
-*MediaLibraryApi* | [**create_subtitle_clipboard_entry**](docs/MediaLibraryApi#create_subtitle_clipboard_entry) | **POST** `/api/2/media/subtitles/clipboard` | 
-*MediaLibraryApi* | [**delete_asset**](docs/MediaLibraryApi#delete_asset) | **DELETE** `/api/2/media/assets/{id}` | 
-*MediaLibraryApi* | [**delete_asset_rating**](docs/MediaLibraryApi#delete_asset_rating) | **DELETE** `/api/2/media/ratings/{id}` | 
-*MediaLibraryApi* | [**delete_asset_subtitle_link**](docs/MediaLibraryApi#delete_asset_subtitle_link) | **DELETE** `/api/2/media/assets/subtitle-links/{id}` | 
-*MediaLibraryApi* | [**delete_comment**](docs/MediaLibraryApi#delete_comment) | **DELETE** `/api/2/media/comments/{id}` | 
-*MediaLibraryApi* | [**delete_custom_field**](docs/MediaLibraryApi#delete_custom_field) | **DELETE** `/api/2/media/custom-fields/{id}` | 
-*MediaLibraryApi* | [**delete_easy_sharing_token_for_bundle**](docs/MediaLibraryApi#delete_easy_sharing_token_for_bundle) | **DELETE** `/api/2/media/bundles/{id}/easy-sharing-token` | 
-*MediaLibraryApi* | [**delete_easy_sharing_token_for_directory**](docs/MediaLibraryApi#delete_easy_sharing_token_for_directory) | **DELETE** `/api/2/media/files/{id}/easy-sharing-token` | 
-*MediaLibraryApi* | [**delete_external_transcoder**](docs/MediaLibraryApi#delete_external_transcoder) | **DELETE** `/api/2/media/external-transcoders/{id}` | 
-*MediaLibraryApi* | [**delete_marker**](docs/MediaLibraryApi#delete_marker) | **DELETE** `/api/2/media/markers/{id}` | 
-*MediaLibraryApi* | [**delete_media_file_template**](docs/MediaLibraryApi#delete_media_file_template) | **DELETE** `/api/2/media/files/templates/{id}` | 
-*MediaLibraryApi* | [**delete_media_library_objects**](docs/MediaLibraryApi#delete_media_library_objects) | **POST** `/api/2/media/delete` | 
-*MediaLibraryApi* | [**delete_media_root**](docs/MediaLibraryApi#delete_media_root) | **DELETE** `/api/2/media/roots/{id}` | 
-*MediaLibraryApi* | [**delete_media_root_permission**](docs/MediaLibraryApi#delete_media_root_permission) | **DELETE** `/api/2/media/root-permissions/{id}` | 
-*MediaLibraryApi* | [**delete_media_tag**](docs/MediaLibraryApi#delete_media_tag) | **DELETE** `/api/2/media/tags/{id}` | 
-*MediaLibraryApi* | [**delete_media_update**](docs/MediaLibraryApi#delete_media_update) | **DELETE** `/api/2/media/updates/{id}` | 
-*MediaLibraryApi* | [**delete_proxy**](docs/MediaLibraryApi#delete_proxy) | **DELETE** `/api/2/media/proxies/{id}` | 
-*MediaLibraryApi* | [**delete_proxy_profile**](docs/MediaLibraryApi#delete_proxy_profile) | **DELETE** `/api/2/media/proxy-profiles/{id}` | 
-*MediaLibraryApi* | [**delete_saved_search**](docs/MediaLibraryApi#delete_saved_search) | **DELETE** `/api/2/media/saved-searches/{id}` | 
-*MediaLibraryApi* | [**delete_subclip**](docs/MediaLibraryApi#delete_subclip) | **DELETE** `/api/2/media/subclips/{id}` | 
-*MediaLibraryApi* | [**delete_subclip_clipboard_entry**](docs/MediaLibraryApi#delete_subclip_clipboard_entry) | **DELETE** `/api/2/media/subclips/clipboard/{id}` | 
-*MediaLibraryApi* | [**delete_subtitle_clipboard_entry**](docs/MediaLibraryApi#delete_subtitle_clipboard_entry) | **DELETE** `/api/2/media/subtitles/clipboard/{id}` | 
-*MediaLibraryApi* | [**discover_media**](docs/MediaLibraryApi#discover_media) | **POST** `/api/2/scanner/discover` | 
-*MediaLibraryApi* | [**download_asset_proxy_file**](docs/MediaLibraryApi#download_asset_proxy_file) | **GET** `/api/2/media/assets/{id}/proxy-files/{filename}` | 
-*MediaLibraryApi* | [**download_media_file**](docs/MediaLibraryApi#download_media_file) | **GET** `/api/2/media/files/{id}/download` | 
-*MediaLibraryApi* | [**download_proxy**](docs/MediaLibraryApi#download_proxy) | **GET** `/api/2/media/proxies/{id}/download` | 
-*MediaLibraryApi* | [**editor_export_xml_for_assset**](docs/MediaLibraryApi#editor_export_xml_for_assset) | **GET** `/api/2/media/editor/asset/{asset_ids}/xml-export` | 
-*MediaLibraryApi* | [**editor_export_xml_for_bundle**](docs/MediaLibraryApi#editor_export_xml_for_bundle) | **GET** `/api/2/media/editor/bundle/{bundle_ids}/xml-export` | 
-*MediaLibraryApi* | [**editor_export_xml_for_project**](docs/MediaLibraryApi#editor_export_xml_for_project) | **GET** `/api/2/media/editor/{id}/xml-export` | 
-*MediaLibraryApi* | [**export_comments_for_avid**](docs/MediaLibraryApi#export_comments_for_avid) | **GET** `/api/2/media/editor/asset/{asset_id}/{export_format}-export/avid-comments` | 
-*MediaLibraryApi* | [**export_editor_timeline**](docs/MediaLibraryApi#export_editor_timeline) | **POST** `/api/2/media/editor/timeline-export` | 
-*MediaLibraryApi* | [**extract_stream**](docs/MediaLibraryApi#extract_stream) | **POST** `/api/2/media/assets/{id}/extract-stream` | 
-*MediaLibraryApi* | [**forget_deleted_media_files**](docs/MediaLibraryApi#forget_deleted_media_files) | **POST** `/api/2/media/files/{id}/forget-deleted` | 
-*MediaLibraryApi* | [**generate_proxies**](docs/MediaLibraryApi#generate_proxies) | **POST** `/api/2/media/proxies` | 
-*MediaLibraryApi* | [**get_all_asset_project_links**](docs/MediaLibraryApi#get_all_asset_project_links) | **GET** `/api/2/media/assets/project-links` | 
-*MediaLibraryApi* | [**get_all_asset_ratings**](docs/MediaLibraryApi#get_all_asset_ratings) | **GET** `/api/2/media/ratings` | 
-*MediaLibraryApi* | [**get_all_asset_subtitle_links**](docs/MediaLibraryApi#get_all_asset_subtitle_links) | **GET** `/api/2/media/assets/subtitle-links` | 
-*MediaLibraryApi* | [**get_all_asset_tape_backups**](docs/MediaLibraryApi#get_all_asset_tape_backups) | **GET** `/api/2/media/backups` | 
-*MediaLibraryApi* | [**get_all_assets**](docs/MediaLibraryApi#get_all_assets) | **GET** `/api/2/media/assets` | 
-*MediaLibraryApi* | [**get_all_bundles_for_media_root**](docs/MediaLibraryApi#get_all_bundles_for_media_root) | **GET** `/api/2/media/bundles/flat/{root}` | 
-*MediaLibraryApi* | [**get_all_bundles_in_subtree**](docs/MediaLibraryApi#get_all_bundles_in_subtree) | **GET** `/api/2/media/bundles/flat/subtree/{file}` | 
-*MediaLibraryApi* | [**get_all_click_links**](docs/MediaLibraryApi#get_all_click_links) | **GET** `/api/2/media/assets/click-links` | 
-*MediaLibraryApi* | [**get_all_comments**](docs/MediaLibraryApi#get_all_comments) | **GET** `/api/2/media/comments` | 
-*MediaLibraryApi* | [**get_all_custom_fields**](docs/MediaLibraryApi#get_all_custom_fields) | **GET** `/api/2/media/custom-fields` | 
-*MediaLibraryApi* | [**get_all_external_transcoders**](docs/MediaLibraryApi#get_all_external_transcoders) | **GET** `/api/2/media/external-transcoders` | 
-*MediaLibraryApi* | [**get_all_markers**](docs/MediaLibraryApi#get_all_markers) | **GET** `/api/2/media/markers` | 
-*MediaLibraryApi* | [**get_all_media_file_bundles**](docs/MediaLibraryApi#get_all_media_file_bundles) | **GET** `/api/2/media/bundles` | 
-*MediaLibraryApi* | [**get_all_media_file_templates**](docs/MediaLibraryApi#get_all_media_file_templates) | **GET** `/api/2/media/files/templates` | 
-*MediaLibraryApi* | [**get_all_media_files**](docs/MediaLibraryApi#get_all_media_files) | **GET** `/api/2/media/files` | 
-*MediaLibraryApi* | [**get_all_media_files_for_bundles**](docs/MediaLibraryApi#get_all_media_files_for_bundles) | **POST** `/api/2/media/files/for-bundles` | 
-*MediaLibraryApi* | [**get_all_media_files_for_media_root**](docs/MediaLibraryApi#get_all_media_files_for_media_root) | **GET** `/api/2/media/files/flat/{root}` | 
-*MediaLibraryApi* | [**get_all_media_files_in_subtree**](docs/MediaLibraryApi#get_all_media_files_in_subtree) | **GET** `/api/2/media/files/flat/subtree/{file}` | 
-*MediaLibraryApi* | [**get_all_media_root_permissions**](docs/MediaLibraryApi#get_all_media_root_permissions) | **GET** `/api/2/media/root-permissions` | 
-*MediaLibraryApi* | [**get_all_media_roots**](docs/MediaLibraryApi#get_all_media_roots) | **GET** `/api/2/media/roots` | 
-*MediaLibraryApi* | [**get_all_media_tags**](docs/MediaLibraryApi#get_all_media_tags) | **GET** `/api/2/media/tags` | 
-*MediaLibraryApi* | [**get_all_media_updates**](docs/MediaLibraryApi#get_all_media_updates) | **GET** `/api/2/media/updates` | 
-*MediaLibraryApi* | [**get_all_proxy_generators**](docs/MediaLibraryApi#get_all_proxy_generators) | **GET** `/api/2/media/proxy-generators` | 
-*MediaLibraryApi* | [**get_all_proxy_profiles**](docs/MediaLibraryApi#get_all_proxy_profiles) | **GET** `/api/2/media/proxy-profiles` | 
-*MediaLibraryApi* | [**get_all_saved_searches**](docs/MediaLibraryApi#get_all_saved_searches) | **GET** `/api/2/media/saved-searches` | 
-*MediaLibraryApi* | [**get_all_subclip_clipboard_entries**](docs/MediaLibraryApi#get_all_subclip_clipboard_entries) | **GET** `/api/2/media/subclips/clipboard` | 
-*MediaLibraryApi* | [**get_all_subclips**](docs/MediaLibraryApi#get_all_subclips) | **GET** `/api/2/media/subclips` | 
-*MediaLibraryApi* | [**get_all_subtitle_clipboard_entries**](docs/MediaLibraryApi#get_all_subtitle_clipboard_entries) | **GET** `/api/2/media/subtitles/clipboard` | 
-*MediaLibraryApi* | [**get_all_transcoder_profiles**](docs/MediaLibraryApi#get_all_transcoder_profiles) | **GET** `/api/2/transcoder-profiles` | 
-*MediaLibraryApi* | [**get_asset**](docs/MediaLibraryApi#get_asset) | **GET** `/api/2/media/assets/{id}` | 
-*MediaLibraryApi* | [**get_asset_rating**](docs/MediaLibraryApi#get_asset_rating) | **GET** `/api/2/media/ratings/{id}` | 
-*MediaLibraryApi* | [**get_asset_subtitle_link**](docs/MediaLibraryApi#get_asset_subtitle_link) | **GET** `/api/2/media/assets/subtitle-links/{id}` | 
-*MediaLibraryApi* | [**get_bookmarked_media_files_directories**](docs/MediaLibraryApi#get_bookmarked_media_files_directories) | **GET** `/api/2/media/files/bookmarks` | 
-*MediaLibraryApi* | [**get_comment**](docs/MediaLibraryApi#get_comment) | **GET** `/api/2/media/comments/{id}` | 
-*MediaLibraryApi* | [**get_custom_field**](docs/MediaLibraryApi#get_custom_field) | **GET** `/api/2/media/custom-fields/{id}` | 
-*MediaLibraryApi* | [**get_easy_sharing_token_for_bundle**](docs/MediaLibraryApi#get_easy_sharing_token_for_bundle) | **GET** `/api/2/media/bundles/{id}/easy-sharing-token` | 
-*MediaLibraryApi* | [**get_easy_sharing_token_for_directory**](docs/MediaLibraryApi#get_easy_sharing_token_for_directory) | **GET** `/api/2/media/files/{id}/easy-sharing-token` | 
-*MediaLibraryApi* | [**get_editor_project**](docs/MediaLibraryApi#get_editor_project) | **GET** `/api/2/media/editor/{id}` | 
-*MediaLibraryApi* | [**get_editor_subtitle**](docs/MediaLibraryApi#get_editor_subtitle) | **GET** `/api/2/media/subtitles/{id}` | 
-*MediaLibraryApi* | [**get_external_transcoder**](docs/MediaLibraryApi#get_external_transcoder) | **GET** `/api/2/media/external-transcoders/{id}` | 
-*MediaLibraryApi* | [**get_frame**](docs/MediaLibraryApi#get_frame) | **GET** `/api/2/media/assets/{id}/frames/{frame}` | 
-*MediaLibraryApi* | [**get_latest_media_update**](docs/MediaLibraryApi#get_latest_media_update) | **GET** `/api/2/media/updates/latest` | 
-*MediaLibraryApi* | [**get_marker**](docs/MediaLibraryApi#get_marker) | **GET** `/api/2/media/markers/{id}` | 
-*MediaLibraryApi* | [**get_media_file**](docs/MediaLibraryApi#get_media_file) | **GET** `/api/2/media/files/{id}` | 
-*MediaLibraryApi* | [**get_media_file_bundle**](docs/MediaLibraryApi#get_media_file_bundle) | **GET** `/api/2/media/bundles/{id}` | 
-*MediaLibraryApi* | [**get_media_file_contents**](docs/MediaLibraryApi#get_media_file_contents) | **GET** `/api/2/media/files/{id}/contents` | 
-*MediaLibraryApi* | [**get_media_file_template**](docs/MediaLibraryApi#get_media_file_template) | **GET** `/api/2/media/files/templates/{id}` | 
-*MediaLibraryApi* | [**get_media_root**](docs/MediaLibraryApi#get_media_root) | **GET** `/api/2/media/roots/{id}` | 
-*MediaLibraryApi* | [**get_media_root_permission**](docs/MediaLibraryApi#get_media_root_permission) | **GET** `/api/2/media/root-permissions/{id}` | 
-*MediaLibraryApi* | [**get_media_tag**](docs/MediaLibraryApi#get_media_tag) | **GET** `/api/2/media/tags/{id}` | 
-*MediaLibraryApi* | [**get_multiple_assets**](docs/MediaLibraryApi#get_multiple_assets) | **POST** `/api/2/media/assets/multiple` | 
-*MediaLibraryApi* | [**get_multiple_bundles**](docs/MediaLibraryApi#get_multiple_bundles) | **POST** `/api/2/media/bundles/multiple` | 
-*MediaLibraryApi* | [**get_multiple_files**](docs/MediaLibraryApi#get_multiple_files) | **POST** `/api/2/media/files/multiple` | 
-*MediaLibraryApi* | [**get_my_media_root_permissions**](docs/MediaLibraryApi#get_my_media_root_permissions) | **GET** `/api/2/media/root-permissions/mine` | 
-*MediaLibraryApi* | [**get_my_resolved_media_root_permissions**](docs/MediaLibraryApi#get_my_resolved_media_root_permissions) | **GET** `/api/2/media/root-permissions/mine/resolved` | 
-*MediaLibraryApi* | [**get_proxy**](docs/MediaLibraryApi#get_proxy) | **GET** `/api/2/media/proxies/{id}` | 
-*MediaLibraryApi* | [**get_proxy_generator**](docs/MediaLibraryApi#get_proxy_generator) | **GET** `/api/2/media/proxy-generators/{id}` | 
-*MediaLibraryApi* | [**get_proxy_profile**](docs/MediaLibraryApi#get_proxy_profile) | **GET** `/api/2/media/proxy-profiles/{id}` | 
-*MediaLibraryApi* | [**get_proxy_profile_proxy_count**](docs/MediaLibraryApi#get_proxy_profile_proxy_count) | **GET** `/api/2/media/proxy-profiles/{id}/proxy-count` | 
-*MediaLibraryApi* | [**get_saved_search**](docs/MediaLibraryApi#get_saved_search) | **GET** `/api/2/media/saved-searches/{id}` | 
-*MediaLibraryApi* | [**get_subclip**](docs/MediaLibraryApi#get_subclip) | **GET** `/api/2/media/subclips/{id}` | 
-*MediaLibraryApi* | [**get_subtitles**](docs/MediaLibraryApi#get_subtitles) | **GET** `/api/2/media/assets/{id}/subtitle/{title}` | 
-*MediaLibraryApi* | [**get_transcoder_profile**](docs/MediaLibraryApi#get_transcoder_profile) | **GET** `/api/2/transcoder-profiles/{id}` | 
-*MediaLibraryApi* | [**get_vantage_workflows**](docs/MediaLibraryApi#get_vantage_workflows) | **GET** `/api/2/media/external-transcoders/{id}/workflows` | 
-*MediaLibraryApi* | [**instantiate_media_file_template**](docs/MediaLibraryApi#instantiate_media_file_template) | **POST** `/api/2/media/files/templates/{id}/instantiate` | 
-*MediaLibraryApi* | [**locate_editor_project_paths**](docs/MediaLibraryApi#locate_editor_project_paths) | **GET** `/api/2/media/editor/{id}/locate-paths` | 
-*MediaLibraryApi* | [**lookup_media_files**](docs/MediaLibraryApi#lookup_media_files) | **POST** `/api/2/media/files/lookup` | 
-*MediaLibraryApi* | [**mark_media_directory_as_showroom**](docs/MediaLibraryApi#mark_media_directory_as_showroom) | **POST** `/api/2/media/files/{id}/showroom` | 
-*MediaLibraryApi* | [**patch_asset**](docs/MediaLibraryApi#patch_asset) | **PATCH** `/api/2/media/assets/{id}` | 
-*MediaLibraryApi* | [**patch_asset_rating**](docs/MediaLibraryApi#patch_asset_rating) | **PATCH** `/api/2/media/ratings/{id}` | 
-*MediaLibraryApi* | [**patch_asset_subtitle_link**](docs/MediaLibraryApi#patch_asset_subtitle_link) | **PATCH** `/api/2/media/assets/subtitle-links/{id}` | 
-*MediaLibraryApi* | [**patch_comment**](docs/MediaLibraryApi#patch_comment) | **PATCH** `/api/2/media/comments/{id}` | 
-*MediaLibraryApi* | [**patch_custom_field**](docs/MediaLibraryApi#patch_custom_field) | **PATCH** `/api/2/media/custom-fields/{id}` | 
-*MediaLibraryApi* | [**patch_editor_project**](docs/MediaLibraryApi#patch_editor_project) | **PATCH** `/api/2/media/editor/{id}` | 
-*MediaLibraryApi* | [**patch_editor_subtitle**](docs/MediaLibraryApi#patch_editor_subtitle) | **PATCH** `/api/2/media/subtitles/{id}` | 
-*MediaLibraryApi* | [**patch_external_transcoder**](docs/MediaLibraryApi#patch_external_transcoder) | **PATCH** `/api/2/media/external-transcoders/{id}` | 
-*MediaLibraryApi* | [**patch_marker**](docs/MediaLibraryApi#patch_marker) | **PATCH** `/api/2/media/markers/{id}` | 
-*MediaLibraryApi* | [**patch_media_file**](docs/MediaLibraryApi#patch_media_file) | **PATCH** `/api/2/media/files/{id}` | 
-*MediaLibraryApi* | [**patch_media_file_template**](docs/MediaLibraryApi#patch_media_file_template) | **PATCH** `/api/2/media/files/templates/{id}` | 
-*MediaLibraryApi* | [**patch_media_root**](docs/MediaLibraryApi#patch_media_root) | **PATCH** `/api/2/media/roots/{id}` | 
-*MediaLibraryApi* | [**patch_media_root_permission**](docs/MediaLibraryApi#patch_media_root_permission) | **PATCH** `/api/2/media/root-permissions/{id}` | 
-*MediaLibraryApi* | [**patch_media_tag**](docs/MediaLibraryApi#patch_media_tag) | **PATCH** `/api/2/media/tags/{id}` | 
-*MediaLibraryApi* | [**patch_proxy_profile**](docs/MediaLibraryApi#patch_proxy_profile) | **PATCH** `/api/2/media/proxy-profiles/{id}` | 
-*MediaLibraryApi* | [**patch_saved_search**](docs/MediaLibraryApi#patch_saved_search) | **PATCH** `/api/2/media/saved-searches/{id}` | 
-*MediaLibraryApi* | [**patch_subclip**](docs/MediaLibraryApi#patch_subclip) | **PATCH** `/api/2/media/subclips/{id}` | 
-*MediaLibraryApi* | [**recursively_tag_media_directory**](docs/MediaLibraryApi#recursively_tag_media_directory) | **POST** `/api/2/media/files/{id}/tag` | 
-*MediaLibraryApi* | [**reindex_media_directory**](docs/MediaLibraryApi#reindex_media_directory) | **POST** `/api/2/media/files/{id}/search-reindex` | 
-*MediaLibraryApi* | [**rename_custom_field**](docs/MediaLibraryApi#rename_custom_field) | **POST** `/api/2/media/custom-fields/{id}/rename` | 
-*MediaLibraryApi* | [**render_sequence**](docs/MediaLibraryApi#render_sequence) | **POST** `/api/2/media/editor/render` | 
-*MediaLibraryApi* | [**render_subclip**](docs/MediaLibraryApi#render_subclip) | **POST** `/api/2/media/subclips/{id}/render` | 
-*MediaLibraryApi* | [**request_media_scan**](docs/MediaLibraryApi#request_media_scan) | **POST** `/api/2/scanner/scan` | 
-*MediaLibraryApi* | [**resolve_comment**](docs/MediaLibraryApi#resolve_comment) | **POST** `/api/2/media/comments/{id}/resolve` | 
-*MediaLibraryApi* | [**share_media_library_objects**](docs/MediaLibraryApi#share_media_library_objects) | **POST** `/api/2/media/share` | 
-*MediaLibraryApi* | [**test_external_transcoder_connection**](docs/MediaLibraryApi#test_external_transcoder_connection) | **POST** `/api/2/media/external-transcoders/test-connection` | 
-*MediaLibraryApi* | [**transition_workflow**](docs/MediaLibraryApi#transition_workflow) | **POST** `/api/2/media/workflow/transition` | 
-*MediaLibraryApi* | [**unbookmark_media_directory**](docs/MediaLibraryApi#unbookmark_media_directory) | **DELETE** `/api/2/media/files/{id}/bookmark` | 
-*MediaLibraryApi* | [**unmark_media_directory_as_showroom**](docs/MediaLibraryApi#unmark_media_directory_as_showroom) | **DELETE** `/api/2/media/files/{id}/showroom` | 
-*MediaLibraryApi* | [**unresolve_comment**](docs/MediaLibraryApi#unresolve_comment) | **POST** `/api/2/media/comments/{id}/unresolve` | 
-*MediaLibraryApi* | [**update_asset**](docs/MediaLibraryApi#update_asset) | **PUT** `/api/2/media/assets/{id}` | 
-*MediaLibraryApi* | [**update_asset_rating**](docs/MediaLibraryApi#update_asset_rating) | **PUT** `/api/2/media/ratings/{id}` | 
-*MediaLibraryApi* | [**update_asset_subtitle_link**](docs/MediaLibraryApi#update_asset_subtitle_link) | **PUT** `/api/2/media/assets/subtitle-links/{id}` | 
-*MediaLibraryApi* | [**update_comment**](docs/MediaLibraryApi#update_comment) | **PUT** `/api/2/media/comments/{id}` | 
-*MediaLibraryApi* | [**update_custom_field**](docs/MediaLibraryApi#update_custom_field) | **PUT** `/api/2/media/custom-fields/{id}` | 
-*MediaLibraryApi* | [**update_editor_project**](docs/MediaLibraryApi#update_editor_project) | **PUT** `/api/2/media/editor/{id}` | 
-*MediaLibraryApi* | [**update_editor_subtitle**](docs/MediaLibraryApi#update_editor_subtitle) | **PUT** `/api/2/media/subtitles/{id}` | 
-*MediaLibraryApi* | [**update_external_transcoder**](docs/MediaLibraryApi#update_external_transcoder) | **PUT** `/api/2/media/external-transcoders/{id}` | 
-*MediaLibraryApi* | [**update_marker**](docs/MediaLibraryApi#update_marker) | **PUT** `/api/2/media/markers/{id}` | 
-*MediaLibraryApi* | [**update_media_file**](docs/MediaLibraryApi#update_media_file) | **PUT** `/api/2/media/files/{id}` | 
-*MediaLibraryApi* | [**update_media_file_template**](docs/MediaLibraryApi#update_media_file_template) | **PUT** `/api/2/media/files/templates/{id}` | 
-*MediaLibraryApi* | [**update_media_root**](docs/MediaLibraryApi#update_media_root) | **PUT** `/api/2/media/roots/{id}` | 
-*MediaLibraryApi* | [**update_media_root_permission**](docs/MediaLibraryApi#update_media_root_permission) | **PUT** `/api/2/media/root-permissions/{id}` | 
-*MediaLibraryApi* | [**update_media_tag**](docs/MediaLibraryApi#update_media_tag) | **PUT** `/api/2/media/tags/{id}` | 
-*MediaLibraryApi* | [**update_proxy_profile**](docs/MediaLibraryApi#update_proxy_profile) | **PUT** `/api/2/media/proxy-profiles/{id}` | 
-*MediaLibraryApi* | [**update_saved_search**](docs/MediaLibraryApi#update_saved_search) | **PUT** `/api/2/media/saved-searches/{id}` | 
-*MediaLibraryApi* | [**update_subclip**](docs/MediaLibraryApi#update_subclip) | **PUT** `/api/2/media/subclips/{id}` | 
-*PrivateApi* | [**delete_stored_image**](docs/PrivateApi#delete_stored_image) | **DELETE** `/api/2/image/{name}` | 
-*PrivateApi* | [**delete_veritone_tdo**](docs/PrivateApi#delete_veritone_tdo) | **DELETE** `/api/2/veritone/connections/{id}/tdo/{tdo_id}` | 
-*PrivateApi* | [**export_non_proxied_assets**](docs/PrivateApi#export_non_proxied_assets) | **GET** `/api/2/private/export/non-proxied/{root_id}` | 
-*PrivateApi* | [**export_non_proxied_assets_for_path**](docs/PrivateApi#export_non_proxied_assets_for_path) | **GET** `/api/2/private/export/non-proxied/{root_id}/{path}` | 
-*PrivateApi* | [**export_updates**](docs/PrivateApi#export_updates) | **GET** `/api/2/private/export/updates/{root_id}` | 
-*PrivateApi* | [**get**](docs/PrivateApi#get) | **GET** `/api/2/private/bootstrap` | 
-*PrivateApi* | [**get_all_veritone_connections**](docs/PrivateApi#get_all_veritone_connections) | **GET** `/api/2/veritone/connections` | 
-*PrivateApi* | [**get_all_veritone_metadata**](docs/PrivateApi#get_all_veritone_metadata) | **GET** `/api/2/veritone/metadata` | 
-*PrivateApi* | [**get_client_side_url**](docs/PrivateApi#get_client_side_url) | **POST** `/api/2/private/client-side-url` | 
-*PrivateApi* | [**get_help_page**](docs/PrivateApi#get_help_page) | **GET** `/api/2/help/{id}` | 
-*PrivateApi* | [**get_locale**](docs/PrivateApi#get_locale) | **GET** `/api/2/private/locale/{lang}` | 
-*PrivateApi* | [**get_proxy_fs_size**](docs/PrivateApi#get_proxy_fs_size) | **GET** `/api/2/private/media/proxyfs-size` | 
-*PrivateApi* | [**get_stored_image**](docs/PrivateApi#get_stored_image) | **GET** `/api/2/image/{name}` | 
-*PrivateApi* | [**get_veritone_connection**](docs/PrivateApi#get_veritone_connection) | **GET** `/api/2/veritone/connections/{id}` | 
-*PrivateApi* | [**get_veritone_engines**](docs/PrivateApi#get_veritone_engines) | **GET** `/api/2/veritone/connections/{id}/engines` | 
-*PrivateApi* | [**get_veritone_jobs**](docs/PrivateApi#get_veritone_jobs) | **GET** `/api/2/veritone/connections/{id}/jobs` | 
-*PrivateApi* | [**get_veritone_metadata**](docs/PrivateApi#get_veritone_metadata) | **GET** `/api/2/veritone/metadata/{id}` | 
-*PrivateApi* | [**install_license**](docs/PrivateApi#install_license) | **POST** `/api/2/license/install` | 
-*PrivateApi* | [**language_server_request**](docs/PrivateApi#language_server_request) | **POST** `/api/2/language-server/{language}` | 
-*PrivateApi* | [**locate_file**](docs/PrivateApi#locate_file) | **POST** `/api/2/private/locate` | 
-*PrivateApi* | [**locate_proxies**](docs/PrivateApi#locate_proxies) | **POST** `/api/2/panel/locate-proxies` | 
-*PrivateApi* | [**upload_stored_image**](docs/PrivateApi#upload_stored_image) | **POST** `/api/2/private/images/upload` | 
-*PrivateApi* | [**upload_to_veritone**](docs/PrivateApi#upload_to_veritone) | **POST** `/api/2/veritone/connections/{id}/upload` | 
-*SatelliteApi* | [**activate_satellite_host**](docs/SatelliteApi#activate_satellite_host) | **POST** `/api/2/rdc/hosts/{id}/activate` | 
-*SatelliteApi* | [**announce_satellite_host**](docs/SatelliteApi#announce_satellite_host) | **POST** `/api/2/rdc/hosts/announce` | 
-*SatelliteApi* | [**create_satellite_session**](docs/SatelliteApi#create_satellite_session) | **POST** `/api/2/rdc/sessions` | 
-*SatelliteApi* | [**delete_satellite_session**](docs/SatelliteApi#delete_satellite_session) | **DELETE** `/api/2/rdc/sessions/{id}` | 
-*SatelliteApi* | [**get_all_satellite_hosts**](docs/SatelliteApi#get_all_satellite_hosts) | **GET** `/api/2/rdc/hosts` | 
-*SatelliteApi* | [**get_all_satellite_sessions**](docs/SatelliteApi#get_all_satellite_sessions) | **GET** `/api/2/rdc/sessions` | 
-*SatelliteApi* | [**get_satellite_host**](docs/SatelliteApi#get_satellite_host) | **GET** `/api/2/rdc/hosts/{id}` | 
-*SatelliteApi* | [**get_satellite_session**](docs/SatelliteApi#get_satellite_session) | **GET** `/api/2/rdc/sessions/{id}` | 
-*SharedstorageApi* | [**get_shared_storage_value**](docs/SharedstorageApi#get_shared_storage_value) | **GET** `/api/2/private/shared-storage/{name}` | 
-*SharedstorageApi* | [**get_user_storage_value**](docs/SharedstorageApi#get_user_storage_value) | **GET** `/api/2/private/user-storage/{name}` | 
-*SharedstorageApi* | [**set_shared_storage_value**](docs/SharedstorageApi#set_shared_storage_value) | **POST** `/api/2/private/shared-storage/{name}` | 
-*SharedstorageApi* | [**set_user_storage_value**](docs/SharedstorageApi#set_user_storage_value) | **POST** `/api/2/private/user-storage/{name}` | 
-*StatusApi* | [**get_alert**](docs/StatusApi#get_alert) | **GET** `/api/2/alerts/{id}` | 
-*StatusApi* | [**get_all_alerts**](docs/StatusApi#get_all_alerts) | **GET** `/api/2/alerts` | 
-*StatusApi* | [**get_telegraf_stats**](docs/StatusApi#get_telegraf_stats) | **GET** `/api/2/telegraf-stats` | 
-*StatusApi* | [**patch_alert**](docs/StatusApi#patch_alert) | **PATCH** `/api/2/alerts/{id}` | 
-*StatusApi* | [**submit_kapacitor_alert**](docs/StatusApi#submit_kapacitor_alert) | **POST** `/api/2/alerts/submit` | 
-*StatusApi* | [**update_alert**](docs/StatusApi#update_alert) | **PUT** `/api/2/alerts/{id}` | 
-*StorageApi* | [**apply_workspace_affinity**](docs/StorageApi#apply_workspace_affinity) | **POST** `/api/2/workspaces/{id}/apply-affinity` | 
-*StorageApi* | [**bookmark_workspace**](docs/StorageApi#bookmark_workspace) | **POST** `/api/2/workspaces/{id}/bookmark` | 
-*StorageApi* | [**calculate_directory_size**](docs/StorageApi#calculate_directory_size) | **POST** `/api/2/filesystem/calculate-directory-size` | 
-*StorageApi* | [**check_in_into_workspace**](docs/StorageApi#check_in_into_workspace) | **POST** `/api/2/workspaces/{id}/check-in` | 
-*StorageApi* | [**check_out_of_workspace**](docs/StorageApi#check_out_of_workspace) | **POST** `/api/2/workspaces/{id}/check-out` | 
-*StorageApi* | [**copy_files**](docs/StorageApi#copy_files) | **POST** `/api/2/filesystem/copy` | 
-*StorageApi* | [**create_file**](docs/StorageApi#create_file) | **POST** `/api/2/files` | 
-*StorageApi* | [**create_path_quota**](docs/StorageApi#create_path_quota) | **POST** `/api/2/volumes/{id}/quotas/path/{relative_path}` | 
-*StorageApi* | [**create_production**](docs/StorageApi#create_production) | **POST** `/api/2/productions` | 
-*StorageApi* | [**create_share**](docs/StorageApi#create_share) | **POST** `/api/2/shares` | 
-*StorageApi* | [**create_snapshot**](docs/StorageApi#create_snapshot) | **POST** `/api/2/snapshots` | 
-*StorageApi* | [**create_template_folder**](docs/StorageApi#create_template_folder) | **POST** `/api/2/private/create-template-folder` | 
-*StorageApi* | [**create_volume**](docs/StorageApi#create_volume) | **POST** `/api/2/volumes` | 
-*StorageApi* | [**create_workspace**](docs/StorageApi#create_workspace) | **POST** `/api/2/workspaces` | 
-*StorageApi* | [**create_workspace_permission**](docs/StorageApi#create_workspace_permission) | **POST** `/api/2/workspace-permissions` | 
-*StorageApi* | [**delete_file**](docs/StorageApi#delete_file) | **DELETE** `/api/2/files/{path}` | 
-*StorageApi* | [**delete_files**](docs/StorageApi#delete_files) | **POST** `/api/2/filesystem/delete` | 
-*StorageApi* | [**delete_path_quota**](docs/StorageApi#delete_path_quota) | **DELETE** `/api/2/volumes/{id}/quotas/path/{relative_path}` | 
-*StorageApi* | [**delete_production**](docs/StorageApi#delete_production) | **DELETE** `/api/2/productions/{id}` | 
-*StorageApi* | [**delete_share**](docs/StorageApi#delete_share) | **DELETE** `/api/2/shares/{id}` | 
-*StorageApi* | [**delete_snapshot**](docs/StorageApi#delete_snapshot) | **DELETE** `/api/2/snapshots/{id}` | 
-*StorageApi* | [**delete_workspace**](docs/StorageApi#delete_workspace) | **DELETE** `/api/2/workspaces/{id}` | 
-*StorageApi* | [**delete_workspace_permission**](docs/StorageApi#delete_workspace_permission) | **DELETE** `/api/2/workspace-permissions/{id}` | 
-*StorageApi* | [**get_all_deleted_workspaces**](docs/StorageApi#get_all_deleted_workspaces) | **GET** `/api/2/workspaces/deleted` | 
-*StorageApi* | [**get_all_productions**](docs/StorageApi#get_all_productions) | **GET** `/api/2/productions` | 
-*StorageApi* | [**get_all_shares**](docs/StorageApi#get_all_shares) | **GET** `/api/2/shares` | 
-*StorageApi* | [**get_all_snapshots**](docs/StorageApi#get_all_snapshots) | **GET** `/api/2/snapshots` | 
-*StorageApi* | [**get_all_volumes**](docs/StorageApi#get_all_volumes) | **GET** `/api/2/volumes` | 
-*StorageApi* | [**get_all_workspace_permissions**](docs/StorageApi#get_all_workspace_permissions) | **GET** `/api/2/workspace-permissions` | 
-*StorageApi* | [**get_all_workspaces**](docs/StorageApi#get_all_workspaces) | **GET** `/api/2/workspaces` | 
-*StorageApi* | [**get_file**](docs/StorageApi#get_file) | **GET** `/api/2/files/{path}` | 
-*StorageApi* | [**get_group_quota**](docs/StorageApi#get_group_quota) | **GET** `/api/2/volumes/{id}/quotas/group/{group_id}` | 
-*StorageApi* | [**get_my_workspaces**](docs/StorageApi#get_my_workspaces) | **GET** `/api/2/workspaces/mine` | 
-*StorageApi* | [**get_path_quota**](docs/StorageApi#get_path_quota) | **GET** `/api/2/volumes/{id}/quotas/path/{relative_path}` | 
-*StorageApi* | [**get_production**](docs/StorageApi#get_production) | **GET** `/api/2/productions/{id}` | 
-*StorageApi* | [**get_root_directory**](docs/StorageApi#get_root_directory) | **GET** `/api/2/files` | 
-*StorageApi* | [**get_samba_dfree_string**](docs/StorageApi#get_samba_dfree_string) | **POST** `/api/2/private/dfree` | 
-*StorageApi* | [**get_share**](docs/StorageApi#get_share) | **GET** `/api/2/shares/{id}` | 
-*StorageApi* | [**get_snapshot**](docs/StorageApi#get_snapshot) | **GET** `/api/2/snapshots/{id}` | 
-*StorageApi* | [**get_user_quota**](docs/StorageApi#get_user_quota) | **GET** `/api/2/volumes/{id}/quotas/user/{user_id}` | 
-*StorageApi* | [**get_volume**](docs/StorageApi#get_volume) | **GET** `/api/2/volumes/{id}` | 
-*StorageApi* | [**get_volume_active_connections**](docs/StorageApi#get_volume_active_connections) | **GET** `/api/2/volumes/{id}/connections` | 
-*StorageApi* | [**get_volume_file_size_distribution**](docs/StorageApi#get_volume_file_size_distribution) | **GET** `/api/2/volumes/{id}/file-size-distribution` | 
-*StorageApi* | [**get_volume_stats**](docs/StorageApi#get_volume_stats) | **GET** `/api/2/volumes/{id}/stats` | 
-*StorageApi* | [**get_workspace**](docs/StorageApi#get_workspace) | **GET** `/api/2/workspaces/{id}` | 
-*StorageApi* | [**get_workspace_permission**](docs/StorageApi#get_workspace_permission) | **GET** `/api/2/workspace-permissions/{id}` | 
-*StorageApi* | [**move_files**](docs/StorageApi#move_files) | **POST** `/api/2/filesystem/move` | 
-*StorageApi* | [**move_workspace**](docs/StorageApi#move_workspace) | **POST** `/api/2/workspaces/{id}/move` | 
-*StorageApi* | [**move_workspace_to_production**](docs/StorageApi#move_workspace_to_production) | **POST** `/api/2/workspaces/{id}/move-to` | 
-*StorageApi* | [**patch_file**](docs/StorageApi#patch_file) | **PATCH** `/api/2/files/{path}` | 
-*StorageApi* | [**patch_production**](docs/StorageApi#patch_production) | **PATCH** `/api/2/productions/{id}` | 
-*StorageApi* | [**patch_share**](docs/StorageApi#patch_share) | **PATCH** `/api/2/shares/{id}` | 
-*StorageApi* | [**patch_snapshot**](docs/StorageApi#patch_snapshot) | **PATCH** `/api/2/snapshots/{id}` | 
-*StorageApi* | [**patch_volume**](docs/StorageApi#patch_volume) | **PATCH** `/api/2/volumes/{id}` | 
-*StorageApi* | [**patch_workspace**](docs/StorageApi#patch_workspace) | **PATCH** `/api/2/workspaces/{id}` | 
-*StorageApi* | [**patch_workspace_permission**](docs/StorageApi#patch_workspace_permission) | **PATCH** `/api/2/workspace-permissions/{id}` | 
-*StorageApi* | [**record_storage_trace**](docs/StorageApi#record_storage_trace) | **POST** `/api/2/filesystem/trace` | 
-*StorageApi* | [**repair_workspace_permissions**](docs/StorageApi#repair_workspace_permissions) | **POST** `/api/2/workspaces/{id}/repair-permissions` | 
-*StorageApi* | [**share_to_home_workspace**](docs/StorageApi#share_to_home_workspace) | **POST** `/api/2/share-to-home-workspace` | 
-*StorageApi* | [**unbookmark_workspace**](docs/StorageApi#unbookmark_workspace) | **DELETE** `/api/2/workspaces/{id}/bookmark` | 
-*StorageApi* | [**unzip_file**](docs/StorageApi#unzip_file) | **POST** `/api/2/filesystem/unzip` | 
-*StorageApi* | [**update_group_quota**](docs/StorageApi#update_group_quota) | **PUT** `/api/2/volumes/{id}/quotas/group/{group_id}` | 
-*StorageApi* | [**update_path_quota**](docs/StorageApi#update_path_quota) | **PUT** `/api/2/volumes/{id}/quotas/path/{relative_path}` | 
-*StorageApi* | [**update_production**](docs/StorageApi#update_production) | **PUT** `/api/2/productions/{id}` | 
-*StorageApi* | [**update_share**](docs/StorageApi#update_share) | **PUT** `/api/2/shares/{id}` | 
-*StorageApi* | [**update_snapshot**](docs/StorageApi#update_snapshot) | **PUT** `/api/2/snapshots/{id}` | 
-*StorageApi* | [**update_user_quota**](docs/StorageApi#update_user_quota) | **PUT** `/api/2/volumes/{id}/quotas/user/{user_id}` | 
-*StorageApi* | [**update_volume**](docs/StorageApi#update_volume) | **PUT** `/api/2/volumes/{id}` | 
-*StorageApi* | [**update_workspace**](docs/StorageApi#update_workspace) | **PUT** `/api/2/workspaces/{id}` | 
-*StorageApi* | [**update_workspace_permission**](docs/StorageApi#update_workspace_permission) | **PUT** `/api/2/workspace-permissions/{id}` | 
-*StorageApi* | [**zip_files**](docs/StorageApi#zip_files) | **POST** `/api/2/filesystem/zip` | 
-*TapeArchiveApi* | [**archive_to_tape**](docs/TapeArchiveApi#archive_to_tape) | **POST** `/api/2/archive/tape/archive` | 
-*TapeArchiveApi* | [**cancel_all_tape_archive_jobs**](docs/TapeArchiveApi#cancel_all_tape_archive_jobs) | **POST** `/api/2/archive/tape/jobs/cancel-all` | 
-*TapeArchiveApi* | [**check_tape**](docs/TapeArchiveApi#check_tape) | **POST** `/api/2/archive/tape/library/check` | 
-*TapeArchiveApi* | [**create_tape**](docs/TapeArchiveApi#create_tape) | **POST** `/api/2/archive/tape/tapes` | 
-*TapeArchiveApi* | [**create_tape_group**](docs/TapeArchiveApi#create_tape_group) | **POST** `/api/2/archive/tape/groups` | 
-*TapeArchiveApi* | [**delete_tape**](docs/TapeArchiveApi#delete_tape) | **DELETE** `/api/2/archive/tape/tapes/{id}` | 
-*TapeArchiveApi* | [**delete_tape_archive_job**](docs/TapeArchiveApi#delete_tape_archive_job) | **DELETE** `/api/2/archive/tape/jobs/{id}` | 
-*TapeArchiveApi* | [**delete_tape_group**](docs/TapeArchiveApi#delete_tape_group) | **DELETE** `/api/2/archive/tape/groups/{id}` | 
-*TapeArchiveApi* | [**format_tape**](docs/TapeArchiveApi#format_tape) | **POST** `/api/2/archive/tape/library/format` | 
-*TapeArchiveApi* | [**get_all_archived_file_entries**](docs/TapeArchiveApi#get_all_archived_file_entries) | **GET** `/api/2/archive/tape/files` | 
-*TapeArchiveApi* | [**get_all_tape_archive_jobs**](docs/TapeArchiveApi#get_all_tape_archive_jobs) | **GET** `/api/2/archive/tape/jobs` | 
-*TapeArchiveApi* | [**get_all_tape_groups**](docs/TapeArchiveApi#get_all_tape_groups) | **GET** `/api/2/archive/tape/groups` | 
-*TapeArchiveApi* | [**get_all_tapes**](docs/TapeArchiveApi#get_all_tapes) | **GET** `/api/2/archive/tape/tapes` | 
-*TapeArchiveApi* | [**get_archived_file_entry**](docs/TapeArchiveApi#get_archived_file_entry) | **GET** `/api/2/archive/tape/files/{id}` | 
-*TapeArchiveApi* | [**get_tape**](docs/TapeArchiveApi#get_tape) | **GET** `/api/2/archive/tape/tapes/{id}` | 
-*TapeArchiveApi* | [**get_tape_archive_job**](docs/TapeArchiveApi#get_tape_archive_job) | **GET** `/api/2/archive/tape/jobs/{id}` | 
-*TapeArchiveApi* | [**get_tape_archive_job_sources**](docs/TapeArchiveApi#get_tape_archive_job_sources) | **GET** `/api/2/archive/tape/jobs/{id}/sources` | 
-*TapeArchiveApi* | [**get_tape_group**](docs/TapeArchiveApi#get_tape_group) | **GET** `/api/2/archive/tape/groups/{id}` | 
-*TapeArchiveApi* | [**get_tape_library_state**](docs/TapeArchiveApi#get_tape_library_state) | **GET** `/api/2/archive/tape/library` | 
-*TapeArchiveApi* | [**load_tape**](docs/TapeArchiveApi#load_tape) | **POST** `/api/2/archive/tape/library/load` | 
-*TapeArchiveApi* | [**move_tape**](docs/TapeArchiveApi#move_tape) | **POST** `/api/2/archive/tape/library/move` | 
-*TapeArchiveApi* | [**patch_tape**](docs/TapeArchiveApi#patch_tape) | **PATCH** `/api/2/archive/tape/tapes/{id}` | 
-*TapeArchiveApi* | [**patch_tape_group**](docs/TapeArchiveApi#patch_tape_group) | **PATCH** `/api/2/archive/tape/groups/{id}` | 
-*TapeArchiveApi* | [**pause_tape_archive_job**](docs/TapeArchiveApi#pause_tape_archive_job) | **POST** `/api/2/archive/tape/jobs/{id}/pause` | 
-*TapeArchiveApi* | [**refresh_tape_library_state**](docs/TapeArchiveApi#refresh_tape_library_state) | **POST** `/api/2/archive/tape/library/refresh` | 
-*TapeArchiveApi* | [**reindex_tape**](docs/TapeArchiveApi#reindex_tape) | **POST** `/api/2/archive/tape/library/reindex` | 
-*TapeArchiveApi* | [**remove_finished_tape_archive_jobs**](docs/TapeArchiveApi#remove_finished_tape_archive_jobs) | **POST** `/api/2/archive/tape/jobs/remove-finished` | 
-*TapeArchiveApi* | [**restart_tape_archive_job**](docs/TapeArchiveApi#restart_tape_archive_job) | **POST** `/api/2/archive/tape/jobs/{id}/restart` | 
-*TapeArchiveApi* | [**restore_from_tape**](docs/TapeArchiveApi#restore_from_tape) | **POST** `/api/2/archive/tape/restore` | 
-*TapeArchiveApi* | [**resume_tape_archive_job**](docs/TapeArchiveApi#resume_tape_archive_job) | **POST** `/api/2/archive/tape/jobs/{id}/resume` | 
-*TapeArchiveApi* | [**search_tape_archive**](docs/TapeArchiveApi#search_tape_archive) | **POST** `/api/2/archive/tape/search` | 
-*TapeArchiveApi* | [**unload_tape**](docs/TapeArchiveApi#unload_tape) | **POST** `/api/2/archive/tape/library/unload` | 
-*TapeArchiveApi* | [**update_tape**](docs/TapeArchiveApi#update_tape) | **PUT** `/api/2/archive/tape/tapes/{id}` | 
-*TapeArchiveApi* | [**update_tape_group**](docs/TapeArchiveApi#update_tape_group) | **PUT** `/api/2/archive/tape/groups/{id}` | 
+*AIApi* | [**abort_ai_dataset_model_creation**](docs/AIApi.md#abort_ai_dataset_model_creation) | **POST** `/api/2/ai/models/{id}/abort` | 
+*AIApi* | [**activate_ai_model**](docs/AIApi.md#activate_ai_model) | **POST** `/api/2/ai/models/{id}/activate` | 
+*AIApi* | [**create_ai_annotation_track**](docs/AIApi.md#create_ai_annotation_track) | **POST** `/api/2/ai/annotations/tracks/create` | 
+*AIApi* | [**create_ai_category**](docs/AIApi.md#create_ai_category) | **POST** `/api/2/ai/categories` | 
+*AIApi* | [**create_ai_dataset**](docs/AIApi.md#create_ai_dataset) | **POST** `/api/2/ai/datasets` | 
+*AIApi* | [**create_ai_dataset_model**](docs/AIApi.md#create_ai_dataset_model) | **POST** `/api/2/ai/models/create` | 
+*AIApi* | [**create_ai_metadata**](docs/AIApi.md#create_ai_metadata) | **POST** `/api/2/ai/metadata/create` | 
+*AIApi* | [**create_ai_model**](docs/AIApi.md#create_ai_model) | **POST** `/api/2/ai/models` | 
+*AIApi* | [**delete_ai_annotation**](docs/AIApi.md#delete_ai_annotation) | **DELETE** `/api/2/ai/annotations/{id}` | 
+*AIApi* | [**delete_ai_annotation_track**](docs/AIApi.md#delete_ai_annotation_track) | **DELETE** `/api/2/ai/annotations/tracks/{id}` | 
+*AIApi* | [**delete_ai_category**](docs/AIApi.md#delete_ai_category) | **DELETE** `/api/2/ai/categories/{id}` | 
+*AIApi* | [**delete_ai_dataset**](docs/AIApi.md#delete_ai_dataset) | **DELETE** `/api/2/ai/datasets/{id}` | 
+*AIApi* | [**delete_ai_model**](docs/AIApi.md#delete_ai_model) | **DELETE** `/api/2/ai/models/{id}` | 
+*AIApi* | [**export_ai_dataset**](docs/AIApi.md#export_ai_dataset) | **POST** `/api/2/ai/datasets/{id}/export` | 
+*AIApi* | [**export_ai_model**](docs/AIApi.md#export_ai_model) | **POST** `/api/2/ai/models/{id}/export` | 
+*AIApi* | [**get_ai_annotation**](docs/AIApi.md#get_ai_annotation) | **GET** `/api/2/ai/annotations/{id}` | 
+*AIApi* | [**get_ai_annotation_image**](docs/AIApi.md#get_ai_annotation_image) | **GET** `/api/2/ai/annotations/{id}/image` | 
+*AIApi* | [**get_ai_category**](docs/AIApi.md#get_ai_category) | **GET** `/api/2/ai/categories/{id}` | 
+*AIApi* | [**get_ai_connection**](docs/AIApi.md#get_ai_connection) | **GET** `/api/2/ai/connections/{id}` | 
+*AIApi* | [**get_ai_dataset**](docs/AIApi.md#get_ai_dataset) | **GET** `/api/2/ai/datasets/{id}` | 
+*AIApi* | [**get_ai_image**](docs/AIApi.md#get_ai_image) | **GET** `/api/2/ai/images/{id}` | 
+*AIApi* | [**get_ai_image_content**](docs/AIApi.md#get_ai_image_content) | **GET** `/api/2/ai/images/{id}/content` | 
+*AIApi* | [**get_ai_metadata**](docs/AIApi.md#get_ai_metadata) | **GET** `/api/2/ai/metadata/{id}` | 
+*AIApi* | [**get_ai_model**](docs/AIApi.md#get_ai_model) | **GET** `/api/2/ai/models/{id}` | 
+*AIApi* | [**get_all_ai_annotation_tracks**](docs/AIApi.md#get_all_ai_annotation_tracks) | **GET** `/api/2/ai/annotations/tracks` | 
+*AIApi* | [**get_all_ai_annotations**](docs/AIApi.md#get_all_ai_annotations) | **GET** `/api/2/ai/annotations` | 
+*AIApi* | [**get_all_ai_categories**](docs/AIApi.md#get_all_ai_categories) | **GET** `/api/2/ai/categories` | 
+*AIApi* | [**get_all_ai_connections**](docs/AIApi.md#get_all_ai_connections) | **GET** `/api/2/ai/connections` | 
+*AIApi* | [**get_all_ai_datasets**](docs/AIApi.md#get_all_ai_datasets) | **GET** `/api/2/ai/datasets` | 
+*AIApi* | [**get_all_ai_images**](docs/AIApi.md#get_all_ai_images) | **GET** `/api/2/ai/images` | 
+*AIApi* | [**get_all_ai_metadata**](docs/AIApi.md#get_all_ai_metadata) | **GET** `/api/2/ai/metadata` | 
+*AIApi* | [**get_all_ai_models**](docs/AIApi.md#get_all_ai_models) | **GET** `/api/2/ai/models` | 
+*AIApi* | [**import_ai_datasets**](docs/AIApi.md#import_ai_datasets) | **POST** `/api/2/ai/datasets/import` | 
+*AIApi* | [**import_ai_models**](docs/AIApi.md#import_ai_models) | **POST** `/api/2/ai/datasets/{id}/import-models` | 
+*AIApi* | [**patch_ai_annotation**](docs/AIApi.md#patch_ai_annotation) | **PATCH** `/api/2/ai/annotations/{id}` | 
+*AIApi* | [**patch_ai_category**](docs/AIApi.md#patch_ai_category) | **PATCH** `/api/2/ai/categories/{id}` | 
+*AIApi* | [**patch_ai_dataset**](docs/AIApi.md#patch_ai_dataset) | **PATCH** `/api/2/ai/datasets/{id}` | 
+*AIApi* | [**patch_ai_model**](docs/AIApi.md#patch_ai_model) | **PATCH** `/api/2/ai/models/{id}` | 
+*AIApi* | [**run_ai_model_inference**](docs/AIApi.md#run_ai_model_inference) | **POST** `/api/2/ai/models/{id}/inference` | 
+*AIApi* | [**update_ai_annotation**](docs/AIApi.md#update_ai_annotation) | **PUT** `/api/2/ai/annotations/{id}` | 
+*AIApi* | [**update_ai_category**](docs/AIApi.md#update_ai_category) | **PUT** `/api/2/ai/categories/{id}` | 
+*AIApi* | [**update_ai_dataset**](docs/AIApi.md#update_ai_dataset) | **PUT** `/api/2/ai/datasets/{id}` | 
+*AIApi* | [**update_ai_model**](docs/AIApi.md#update_ai_model) | **PUT** `/api/2/ai/models/{id}` | 
+*AIApi* | [**upload_ai_image**](docs/AIApi.md#upload_ai_image) | **POST** `/api/2/ai/images/upload` | 
+*AWSApi* | [**create_aws_account**](docs/AWSApi.md#create_aws_account) | **POST** `/api/2/aws-accounts` | 
+*AWSApi* | [**delete_aws_account**](docs/AWSApi.md#delete_aws_account) | **DELETE** `/api/2/aws-accounts/{id}` | 
+*AWSApi* | [**get_all_aws_accounts**](docs/AWSApi.md#get_all_aws_accounts) | **GET** `/api/2/aws-accounts` | 
+*AWSApi* | [**get_aws_account**](docs/AWSApi.md#get_aws_account) | **GET** `/api/2/aws-accounts/{id}` | 
+*AWSApi* | [**get_aws_account_sns_topics**](docs/AWSApi.md#get_aws_account_sns_topics) | **GET** `/api/2/aws-accounts/{id}/sns/topics` | 
+*AWSApi* | [**patch_aws_account**](docs/AWSApi.md#patch_aws_account) | **PATCH** `/api/2/aws-accounts/{id}` | 
+*AWSApi* | [**test_aws_account_credentials**](docs/AWSApi.md#test_aws_account_credentials) | **POST** `/api/2/aws-accounts/test-credentials` | 
+*AWSApi* | [**update_aws_account**](docs/AWSApi.md#update_aws_account) | **PUT** `/api/2/aws-accounts/{id}` | 
+*AuthApi* | [**check_auth_ticket**](docs/AuthApi.md#check_auth_ticket) | **POST** `/api/2/auth/ticket/check` | 
+*AuthApi* | [**create_api_token**](docs/AuthApi.md#create_api_token) | **POST** `/api/2/api-tokens` | 
+*AuthApi* | [**create_auth_ticket**](docs/AuthApi.md#create_auth_ticket) | **POST** `/api/2/auth/ticket` | 
+*AuthApi* | [**create_saml_provider**](docs/AuthApi.md#create_saml_provider) | **POST** `/api/2/auth/saml` | 
+*AuthApi* | [**delete_access_token**](docs/AuthApi.md#delete_access_token) | **DELETE** `/api/2/auth/access-tokens/{id}` | 
+*AuthApi* | [**delete_api_token**](docs/AuthApi.md#delete_api_token) | **DELETE** `/api/2/api-tokens/{id}` | 
+*AuthApi* | [**delete_saml_provider**](docs/AuthApi.md#delete_saml_provider) | **DELETE** `/api/2/auth/saml/{id}` | 
+*AuthApi* | [**generate_password**](docs/AuthApi.md#generate_password) | **POST** `/api/2/auth/generate-password` | 
+*AuthApi* | [**get_access_token**](docs/AuthApi.md#get_access_token) | **GET** `/api/2/auth/access-tokens/{id}` | 
+*AuthApi* | [**get_all_access_tokens**](docs/AuthApi.md#get_all_access_tokens) | **GET** `/api/2/auth/access-tokens` | 
+*AuthApi* | [**get_all_api_tokens**](docs/AuthApi.md#get_all_api_tokens) | **GET** `/api/2/api-tokens` | 
+*AuthApi* | [**get_all_saml_providers**](docs/AuthApi.md#get_all_saml_providers) | **GET** `/api/2/auth/saml` | 
+*AuthApi* | [**get_api_token**](docs/AuthApi.md#get_api_token) | **GET** `/api/2/api-tokens/{id}` | 
+*AuthApi* | [**get_saml_provider**](docs/AuthApi.md#get_saml_provider) | **GET** `/api/2/auth/saml/{id}` | 
+*AuthApi* | [**get_saml_service_provider_metadata**](docs/AuthApi.md#get_saml_service_provider_metadata) | **GET** `/api/2/auth/saml/{id}/metadata` | 
+*AuthApi* | [**login**](docs/AuthApi.md#login) | **POST** `/api/2/auth/login` | 
+*AuthApi* | [**logout**](docs/AuthApi.md#logout) | **POST** `/api/2/auth/logout` | 
+*AuthApi* | [**logout_page**](docs/AuthApi.md#logout_page) | **GET** `/api/2/auth/logout` | 
+*AuthApi* | [**parse_samlidp_metadata**](docs/AuthApi.md#parse_samlidp_metadata) | **POST** `/api/2/auth/saml/parse-idp-metadata` | 
+*AuthApi* | [**patch_api_token**](docs/AuthApi.md#patch_api_token) | **PATCH** `/api/2/api-tokens/{id}` | 
+*AuthApi* | [**patch_saml_provider**](docs/AuthApi.md#patch_saml_provider) | **PATCH** `/api/2/auth/saml/{id}` | 
+*AuthApi* | [**receive_saml_auth_assertion**](docs/AuthApi.md#receive_saml_auth_assertion) | **POST** `/api/2/auth/saml/{id}/assertion` | 
+*AuthApi* | [**refresh_samlidp_metadata**](docs/AuthApi.md#refresh_samlidp_metadata) | **POST** `/api/2/auth/saml/{id}/refresh-idp-metadata` | 
+*AuthApi* | [**reset_password**](docs/AuthApi.md#reset_password) | **POST** `/api/2/auth/reset-password` | 
+*AuthApi* | [**return_from_saml_auth**](docs/AuthApi.md#return_from_saml_auth) | **GET** `/api/2/auth/saml/{id}/sso/return` | 
+*AuthApi* | [**return_from_saml_logout**](docs/AuthApi.md#return_from_saml_logout) | **GET** `/api/2/auth/saml/{id}/sls/return` | 
+*AuthApi* | [**send_access_token_email_notification**](docs/AuthApi.md#send_access_token_email_notification) | **POST** `/api/2/auth/access-tokens/{id}/email` | 
+*AuthApi* | [**start_impersonation**](docs/AuthApi.md#start_impersonation) | **POST** `/api/2/auth/impersonation` | 
+*AuthApi* | [**start_saml_auth**](docs/AuthApi.md#start_saml_auth) | **GET** `/api/2/auth/saml/{id}/sso` | 
+*AuthApi* | [**start_saml_logout**](docs/AuthApi.md#start_saml_logout) | **GET** `/api/2/auth/saml/{id}/sls` | 
+*AuthApi* | [**stop_impersonation**](docs/AuthApi.md#stop_impersonation) | **POST** `/api/2/auth/impersonation/stop` | 
+*AuthApi* | [**update_api_token**](docs/AuthApi.md#update_api_token) | **PUT** `/api/2/api-tokens/{id}` | 
+*AuthApi* | [**update_saml_provider**](docs/AuthApi.md#update_saml_provider) | **PUT** `/api/2/auth/saml/{id}` | 
+*AutomationApi* | [**abort_task**](docs/AutomationApi.md#abort_task) | **POST** `/api/2/tasks/{id}/abort` | 
+*AutomationApi* | [**create_job**](docs/AutomationApi.md#create_job) | **POST** `/api/2/jobs` | 
+*AutomationApi* | [**create_schedule**](docs/AutomationApi.md#create_schedule) | **POST** `/api/2/schedules` | 
+*AutomationApi* | [**create_subtask**](docs/AutomationApi.md#create_subtask) | **POST** `/api/2/subtasks` | 
+*AutomationApi* | [**delete_finished_tasks**](docs/AutomationApi.md#delete_finished_tasks) | **DELETE** `/api/2/tasks/finished` | 
+*AutomationApi* | [**delete_job**](docs/AutomationApi.md#delete_job) | **DELETE** `/api/2/jobs/{id}` | 
+*AutomationApi* | [**delete_schedule**](docs/AutomationApi.md#delete_schedule) | **DELETE** `/api/2/schedules/{id}` | 
+*AutomationApi* | [**delete_subtask**](docs/AutomationApi.md#delete_subtask) | **DELETE** `/api/2/subtasks/{id}` | 
+*AutomationApi* | [**delete_task**](docs/AutomationApi.md#delete_task) | **DELETE** `/api/2/tasks/{id}` | 
+*AutomationApi* | [**download_all_task_logs**](docs/AutomationApi.md#download_all_task_logs) | **GET** `/api/2/tasks/logs/download` | 
+*AutomationApi* | [**download_task_log**](docs/AutomationApi.md#download_task_log) | **GET** `/api/2/tasks/{id}/log/download` | 
+*AutomationApi* | [**export_job**](docs/AutomationApi.md#export_job) | **GET** `/api/2/jobs/{id}/export` | 
+*AutomationApi* | [**get_all_events**](docs/AutomationApi.md#get_all_events) | **GET** `/api/2/events` | 
+*AutomationApi* | [**get_all_jobs**](docs/AutomationApi.md#get_all_jobs) | **GET** `/api/2/jobs` | 
+*AutomationApi* | [**get_all_schedules**](docs/AutomationApi.md#get_all_schedules) | **GET** `/api/2/schedules` | 
+*AutomationApi* | [**get_all_subtasks**](docs/AutomationApi.md#get_all_subtasks) | **GET** `/api/2/subtasks` | 
+*AutomationApi* | [**get_all_task_queues**](docs/AutomationApi.md#get_all_task_queues) | **GET** `/api/2/tasks/queues` | 
+*AutomationApi* | [**get_all_task_types**](docs/AutomationApi.md#get_all_task_types) | **GET** `/api/2/tasks/types` | 
+*AutomationApi* | [**get_all_tasks**](docs/AutomationApi.md#get_all_tasks) | **GET** `/api/2/tasks` | 
+*AutomationApi* | [**get_event**](docs/AutomationApi.md#get_event) | **GET** `/api/2/events/{id}` | 
+*AutomationApi* | [**get_finished_tasks**](docs/AutomationApi.md#get_finished_tasks) | **GET** `/api/2/tasks/finished` | 
+*AutomationApi* | [**get_job**](docs/AutomationApi.md#get_job) | **GET** `/api/2/jobs/{id}` | 
+*AutomationApi* | [**get_pending_tasks**](docs/AutomationApi.md#get_pending_tasks) | **GET** `/api/2/tasks/pending` | 
+*AutomationApi* | [**get_python_environments**](docs/AutomationApi.md#get_python_environments) | **GET** `/api/2/python/environments` | 
+*AutomationApi* | [**get_schedule**](docs/AutomationApi.md#get_schedule) | **GET** `/api/2/schedules/{id}` | 
+*AutomationApi* | [**get_subtask**](docs/AutomationApi.md#get_subtask) | **GET** `/api/2/subtasks/{id}` | 
+*AutomationApi* | [**get_task**](docs/AutomationApi.md#get_task) | **GET** `/api/2/tasks/{id}` | 
+*AutomationApi* | [**get_task_log**](docs/AutomationApi.md#get_task_log) | **GET** `/api/2/tasks/{id}/log` | 
+*AutomationApi* | [**get_task_type**](docs/AutomationApi.md#get_task_type) | **GET** `/api/2/tasks/types/{type}` | 
+*AutomationApi* | [**get_tasks_summary**](docs/AutomationApi.md#get_tasks_summary) | **GET** `/api/2/tasks/summary` | 
+*AutomationApi* | [**import_job**](docs/AutomationApi.md#import_job) | **POST** `/api/2/jobs/import` | 
+*AutomationApi* | [**kill_all_pending_tasks**](docs/AutomationApi.md#kill_all_pending_tasks) | **DELETE** `/api/2/tasks/pending` | 
+*AutomationApi* | [**kill_task**](docs/AutomationApi.md#kill_task) | **POST** `/api/2/tasks/{id}/kill` | 
+*AutomationApi* | [**patch_job**](docs/AutomationApi.md#patch_job) | **PATCH** `/api/2/jobs/{id}` | 
+*AutomationApi* | [**patch_schedule**](docs/AutomationApi.md#patch_schedule) | **PATCH** `/api/2/schedules/{id}` | 
+*AutomationApi* | [**patch_subtask**](docs/AutomationApi.md#patch_subtask) | **PATCH** `/api/2/subtasks/{id}` | 
+*AutomationApi* | [**restart_task**](docs/AutomationApi.md#restart_task) | **POST** `/api/2/tasks/{id}/restart` | 
+*AutomationApi* | [**start_job**](docs/AutomationApi.md#start_job) | **POST** `/api/2/jobs/{id}/start` | 
+*AutomationApi* | [**start_task**](docs/AutomationApi.md#start_task) | **POST** `/api/2/tasks/start` | 
+*AutomationApi* | [**update_job**](docs/AutomationApi.md#update_job) | **PUT** `/api/2/jobs/{id}` | 
+*AutomationApi* | [**update_schedule**](docs/AutomationApi.md#update_schedule) | **PUT** `/api/2/schedules/{id}` | 
+*AutomationApi* | [**update_subtask**](docs/AutomationApi.md#update_subtask) | **PUT** `/api/2/subtasks/{id}` | 
+*ClickApi* | [**abort_click_upload**](docs/ClickApi.md#abort_click_upload) | **DELETE** `/api/2/click/uploads/{upload_id}` | 
+*ClickApi* | [**add_assets_to_click_gallery**](docs/ClickApi.md#add_assets_to_click_gallery) | **POST** `/api/2/click/connections/{connection_id}/galleries/{id}/add-assets` | 
+*ClickApi* | [**continue_click_upload_in_background**](docs/ClickApi.md#continue_click_upload_in_background) | **POST** `/api/2/click/uploads/{upload_id}/background` | 
+*ClickApi* | [**create_click_gallery**](docs/ClickApi.md#create_click_gallery) | **POST** `/api/2/click/connections/{connection_id}/galleries` | 
+*ClickApi* | [**create_click_gallery_link**](docs/ClickApi.md#create_click_gallery_link) | **POST** `/api/2/click/connections/{connection_id}/gallery-links` | 
+*ClickApi* | [**delete_click_gallery_link**](docs/ClickApi.md#delete_click_gallery_link) | **DELETE** `/api/2/click/connections/{connection_id}/gallery-links/{id}` | 
+*ClickApi* | [**get_all_click_galleries**](docs/ClickApi.md#get_all_click_galleries) | **GET** `/api/2/click/connections/{connection_id}/galleries` | 
+*ClickApi* | [**get_all_click_gallery_links**](docs/ClickApi.md#get_all_click_gallery_links) | **GET** `/api/2/click/connections/{connection_id}/gallery-links` | 
+*ClickApi* | [**get_click_gallery**](docs/ClickApi.md#get_click_gallery) | **GET** `/api/2/click/connections/{connection_id}/galleries/{id}` | 
+*ClickApi* | [**get_click_gallery_link**](docs/ClickApi.md#get_click_gallery_link) | **GET** `/api/2/click/connections/{connection_id}/gallery-links/{id}` | 
+*ClickApi* | [**send_click_gallery_link_email**](docs/ClickApi.md#send_click_gallery_link_email) | **POST** `/api/2/click/connections/{connection_id}/gallery-links/{link_id}/send` | 
+*ClickApi* | [**start_click_upload**](docs/ClickApi.md#start_click_upload) | **POST** `/api/2/click/uploads` | 
+*IntegrationsApi* | [**delete_slack_connection**](docs/IntegrationsApi.md#delete_slack_connection) | **DELETE** `/api/2/integrations/slack/{id}` | 
+*IntegrationsApi* | [**delete_teams_connection**](docs/IntegrationsApi.md#delete_teams_connection) | **DELETE** `/api/2/integrations/teams/{id}` | 
+*IntegrationsApi* | [**get_all_slack_connections**](docs/IntegrationsApi.md#get_all_slack_connections) | **GET** `/api/2/integrations/slack` | 
+*IntegrationsApi* | [**get_all_teams_connections**](docs/IntegrationsApi.md#get_all_teams_connections) | **GET** `/api/2/integrations/teams` | 
+*IntegrationsApi* | [**get_slack_channels**](docs/IntegrationsApi.md#get_slack_channels) | **GET** `/api/2/integrations/slack/{id}/channels` | 
+*IntegrationsApi* | [**get_slack_connection**](docs/IntegrationsApi.md#get_slack_connection) | **GET** `/api/2/integrations/slack/{id}` | 
+*IntegrationsApi* | [**get_slack_emoji**](docs/IntegrationsApi.md#get_slack_emoji) | **GET** `/api/2/integrations/slack/{id}/emoji` | 
+*IntegrationsApi* | [**get_slack_users**](docs/IntegrationsApi.md#get_slack_users) | **GET** `/api/2/integrations/slack/{id}/users` | 
+*IntegrationsApi* | [**get_teams_channels**](docs/IntegrationsApi.md#get_teams_channels) | **GET** `/api/2/integrations/teams/{id}/channels` | 
+*IntegrationsApi* | [**get_teams_connection**](docs/IntegrationsApi.md#get_teams_connection) | **GET** `/api/2/integrations/teams/{id}` | 
+*IntegrationsApi* | [**get_teams_users**](docs/IntegrationsApi.md#get_teams_users) | **GET** `/api/2/integrations/teams/{id}/users` | 
+*IntegrationsApi* | [**patch_slack_connection**](docs/IntegrationsApi.md#patch_slack_connection) | **PATCH** `/api/2/integrations/slack/{id}` | 
+*IntegrationsApi* | [**patch_teams_connection**](docs/IntegrationsApi.md#patch_teams_connection) | **PATCH** `/api/2/integrations/teams/{id}` | 
+*IntegrationsApi* | [**send_slack_message**](docs/IntegrationsApi.md#send_slack_message) | **POST** `/api/2/integrations/slack/{id}/message` | 
+*IntegrationsApi* | [**send_teams_message**](docs/IntegrationsApi.md#send_teams_message) | **POST** `/api/2/integrations/teams/{id}/send-message` | 
+*IntegrationsApi* | [**start_slack_connection_flow**](docs/IntegrationsApi.md#start_slack_connection_flow) | **GET** `/api/2/integrations/slack/connect` | 
+*IntegrationsApi* | [**start_slack_connection_token_refresh_flow**](docs/IntegrationsApi.md#start_slack_connection_token_refresh_flow) | **GET** `/api/2/integrations/slack/{id}/refresh-token` | 
+*IntegrationsApi* | [**start_teams_connection_flow**](docs/IntegrationsApi.md#start_teams_connection_flow) | **GET** `/api/2/integrations/teams/connect` | 
+*IntegrationsApi* | [**start_teams_connection_token_refresh_flow**](docs/IntegrationsApi.md#start_teams_connection_token_refresh_flow) | **GET** `/api/2/integrations/teams/{id}/refresh-token` | 
+*IntegrationsApi* | [**update_slack_connection**](docs/IntegrationsApi.md#update_slack_connection) | **PUT** `/api/2/integrations/slack/{id}` | 
+*IntegrationsApi* | [**update_teams_connection**](docs/IntegrationsApi.md#update_teams_connection) | **PUT** `/api/2/integrations/teams/{id}` | 
+*MainApi* | [**apply_configuration**](docs/MainApi.md#apply_configuration) | **POST** `/api/2/configuration/apply` | 
+*MainApi* | [**beep**](docs/MainApi.md#beep) | **POST** `/api/2/system/beep` | 
+*MainApi* | [**check_certificate**](docs/MainApi.md#check_certificate) | **POST** `/api/2/system/certificate/check` | 
+*MainApi* | [**check_chunk_uploaded**](docs/MainApi.md#check_chunk_uploaded) | **GET** `/api/2/uploads/chunk` | 
+*MainApi* | [**check_internet_connectivity**](docs/MainApi.md#check_internet_connectivity) | **POST** `/api/2/system/check-connectivity` | 
+*MainApi* | [**check_stor_next_license**](docs/MainApi.md#check_stor_next_license) | **POST** `/api/2/stornext-license/check` | 
+*MainApi* | [**collect_diagnostics**](docs/MainApi.md#collect_diagnostics) | **POST** `/api/2/system/collect-diagnostics` | 
+*MainApi* | [**create_archive**](docs/MainApi.md#create_archive) | **POST** `/api/2/download-archive/create` | 
+*MainApi* | [**create_cloud_account**](docs/MainApi.md#create_cloud_account) | **POST** `/api/2/cloud/accounts` | 
+*MainApi* | [**create_filesystem_permission**](docs/MainApi.md#create_filesystem_permission) | **POST** `/api/2/filesystem-permissions` | 
+*MainApi* | [**create_group**](docs/MainApi.md#create_group) | **POST** `/api/2/groups` | 
+*MainApi* | [**create_home_workspace**](docs/MainApi.md#create_home_workspace) | **POST** `/api/2/users/{id}/home` | 
+*MainApi* | [**create_ntp_server**](docs/MainApi.md#create_ntp_server) | **POST** `/api/2/system/time/servers` | 
+*MainApi* | [**create_user**](docs/MainApi.md#create_user) | **POST** `/api/2/users` | 
+*MainApi* | [**create_workstation**](docs/MainApi.md#create_workstation) | **POST** `/api/2/workstations` | 
+*MainApi* | [**delete_cloud_account**](docs/MainApi.md#delete_cloud_account) | **DELETE** `/api/2/cloud/accounts/{id}` | 
+*MainApi* | [**delete_download_archive**](docs/MainApi.md#delete_download_archive) | **DELETE** `/api/2/download-archive/{id}` | 
+*MainApi* | [**delete_filesystem_permission**](docs/MainApi.md#delete_filesystem_permission) | **DELETE** `/api/2/filesystem-permissions/{id}` | 
+*MainApi* | [**delete_group**](docs/MainApi.md#delete_group) | **DELETE** `/api/2/groups/{id}` | 
+*MainApi* | [**delete_home_workspace**](docs/MainApi.md#delete_home_workspace) | **DELETE** `/api/2/users/{id}/home` | 
+*MainApi* | [**delete_ntp_server**](docs/MainApi.md#delete_ntp_server) | **DELETE** `/api/2/system/time/servers/{id}` | 
+*MainApi* | [**delete_user**](docs/MainApi.md#delete_user) | **DELETE** `/api/2/users/{id}` | 
+*MainApi* | [**delete_workstation**](docs/MainApi.md#delete_workstation) | **DELETE** `/api/2/workstations/{id}` | 
+*MainApi* | [**disable_user_totp**](docs/MainApi.md#disable_user_totp) | **DELETE** `/api/2/users/{id}/totp` | 
+*MainApi* | [**enable_user_totp**](docs/MainApi.md#enable_user_totp) | **POST** `/api/2/users/{id}/totp` | 
+*MainApi* | [**finish_upload**](docs/MainApi.md#finish_upload) | **POST** `/api/2/uploads/finish` | 
+*MainApi* | [**fix_ldap_group_memberships**](docs/MainApi.md#fix_ldap_group_memberships) | **POST** `/api/2/ldap-servers/{id}/fix-memberships` | 
+*MainApi* | [**get_all_client_sessions**](docs/MainApi.md#get_all_client_sessions) | **GET** `/api/2/client-sessions` | 
+*MainApi* | [**get_all_cloud_accounts**](docs/MainApi.md#get_all_cloud_accounts) | **GET** `/api/2/cloud/accounts` | 
+*MainApi* | [**get_all_download_archives**](docs/MainApi.md#get_all_download_archives) | **GET** `/api/2/download-archive` | 
+*MainApi* | [**get_all_downloads**](docs/MainApi.md#get_all_downloads) | **GET** `/api/2/downloads` | 
+*MainApi* | [**get_all_filesystem_permissions**](docs/MainApi.md#get_all_filesystem_permissions) | **GET** `/api/2/filesystem-permissions` | 
+*MainApi* | [**get_all_groups**](docs/MainApi.md#get_all_groups) | **GET** `/api/2/groups` | 
+*MainApi* | [**get_all_ldap_servers**](docs/MainApi.md#get_all_ldap_servers) | **GET** `/api/2/ldap-servers` | 
+*MainApi* | [**get_all_ntp_servers**](docs/MainApi.md#get_all_ntp_servers) | **GET** `/api/2/system/time/servers` | 
+*MainApi* | [**get_all_storage_nodes**](docs/MainApi.md#get_all_storage_nodes) | **GET** `/api/2/nodes` | 
+*MainApi* | [**get_all_users**](docs/MainApi.md#get_all_users) | **GET** `/api/2/users` | 
+*MainApi* | [**get_all_workstations**](docs/MainApi.md#get_all_workstations) | **GET** `/api/2/workstations` | 
+*MainApi* | [**get_certificate_configuration**](docs/MainApi.md#get_certificate_configuration) | **GET** `/api/2/system/certificate` | 
+*MainApi* | [**get_client_download_file**](docs/MainApi.md#get_client_download_file) | **GET** `/api/2/downloads/clients/{file}` | 
+*MainApi* | [**get_client_downloads**](docs/MainApi.md#get_client_downloads) | **GET** `/api/2/downloads/clients` | 
+*MainApi* | [**get_client_session**](docs/MainApi.md#get_client_session) | **GET** `/api/2/client-sessions/{id}` | 
+*MainApi* | [**get_cloud_account**](docs/MainApi.md#get_cloud_account) | **GET** `/api/2/cloud/accounts/{id}` | 
+*MainApi* | [**get_cloud_account_storage_roots**](docs/MainApi.md#get_cloud_account_storage_roots) | **GET** `/api/2/cloud/accounts/{id}/storage-roots` | 
+*MainApi* | [**get_current_workstation**](docs/MainApi.md#get_current_workstation) | **GET** `/api/2/workstations/current` | 
+*MainApi* | [**get_download**](docs/MainApi.md#get_download) | **GET** `/api/2/downloads/{id}` | 
+*MainApi* | [**get_download_archive**](docs/MainApi.md#get_download_archive) | **GET** `/api/2/download-archive/{id}` | 
+*MainApi* | [**get_download_archive_file**](docs/MainApi.md#get_download_archive_file) | **GET** `/api/2/download-archive/{id}/download` | 
+*MainApi* | [**get_download_file**](docs/MainApi.md#get_download_file) | **GET** `/api/2/downloads/{id}/download` | 
+*MainApi* | [**get_download_icon**](docs/MainApi.md#get_download_icon) | **GET** `/api/2/downloads/{id}/icon` | 
+*MainApi* | [**get_filesystem_permission**](docs/MainApi.md#get_filesystem_permission) | **GET** `/api/2/filesystem-permissions/{id}` | 
+*MainApi* | [**get_group**](docs/MainApi.md#get_group) | **GET** `/api/2/groups/{id}` | 
+*MainApi* | [**get_home_workspace**](docs/MainApi.md#get_home_workspace) | **GET** `/api/2/users/{id}/home` | 
+*MainApi* | [**get_ipmi_configuration**](docs/MainApi.md#get_ipmi_configuration) | **GET** `/api/2/nodes/{id}/ipmi` | 
+*MainApi* | [**get_ldap_server**](docs/MainApi.md#get_ldap_server) | **GET** `/api/2/ldap-servers/{id}` | 
+*MainApi* | [**get_ldap_server_groups**](docs/MainApi.md#get_ldap_server_groups) | **GET** `/api/2/ldap-servers/{id}/groups` | 
+*MainApi* | [**get_ldap_server_users**](docs/MainApi.md#get_ldap_server_users) | **GET** `/api/2/ldap-servers/{id}/users` | 
+*MainApi* | [**get_license**](docs/MainApi.md#get_license) | **GET** `/api/2/license` | 
+*MainApi* | [**get_local_time**](docs/MainApi.md#get_local_time) | **GET** `/api/2/system/time` | 
+*MainApi* | [**get_log**](docs/MainApi.md#get_log) | **GET** `/api/2/system/log/{path}` | 
+*MainApi* | [**get_node_ipmi_sensors**](docs/MainApi.md#get_node_ipmi_sensors) | **GET** `/api/2/nodes/{id}/sensors` | 
+*MainApi* | [**get_node_stats**](docs/MainApi.md#get_node_stats) | **GET** `/api/2/nodes/{id}/stats` | 
+*MainApi* | [**get_ntp_server**](docs/MainApi.md#get_ntp_server) | **GET** `/api/2/system/time/servers/{id}` | 
+*MainApi* | [**get_parameters**](docs/MainApi.md#get_parameters) | **GET** `/api/2/parameters` | 
+*MainApi* | [**get_profile**](docs/MainApi.md#get_profile) | **GET** `/api/2/users/me` | 
+*MainApi* | [**get_release_notes**](docs/MainApi.md#get_release_notes) | **GET** `/api/2/release-notes` | 
+*MainApi* | [**get_service_status**](docs/MainApi.md#get_service_status) | **GET** `/api/2/nodes/{id}/services/{service}` | 
+*MainApi* | [**get_smtp_configuration**](docs/MainApi.md#get_smtp_configuration) | **GET** `/api/2/system/smtp` | 
+*MainApi* | [**get_stor_next_license**](docs/MainApi.md#get_stor_next_license) | **GET** `/api/2/stornext-license` | 
+*MainApi* | [**get_storage_node**](docs/MainApi.md#get_storage_node) | **GET** `/api/2/nodes/{id}` | 
+*MainApi* | [**get_system_info**](docs/MainApi.md#get_system_info) | **GET** `/api/2/system/info` | 
+*MainApi* | [**get_user**](docs/MainApi.md#get_user) | **GET** `/api/2/users/{id}` | 
+*MainApi* | [**get_workstation**](docs/MainApi.md#get_workstation) | **GET** `/api/2/workstations/{id}` | 
+*MainApi* | [**install_stor_next_license**](docs/MainApi.md#install_stor_next_license) | **POST** `/api/2/stornext-license` | 
+*MainApi* | [**patch_cloud_account**](docs/MainApi.md#patch_cloud_account) | **PATCH** `/api/2/cloud/accounts/{id}` | 
+*MainApi* | [**patch_current_workstation**](docs/MainApi.md#patch_current_workstation) | **PATCH** `/api/2/workstations/current` | 
+*MainApi* | [**patch_download_archive**](docs/MainApi.md#patch_download_archive) | **PATCH** `/api/2/download-archive/{id}` | 
+*MainApi* | [**patch_filesystem_permission**](docs/MainApi.md#patch_filesystem_permission) | **PATCH** `/api/2/filesystem-permissions/{id}` | 
+*MainApi* | [**patch_group**](docs/MainApi.md#patch_group) | **PATCH** `/api/2/groups/{id}` | 
+*MainApi* | [**patch_ntp_server**](docs/MainApi.md#patch_ntp_server) | **PATCH** `/api/2/system/time/servers/{id}` | 
+*MainApi* | [**patch_profile**](docs/MainApi.md#patch_profile) | **PATCH** `/api/2/users/me` | 
+*MainApi* | [**patch_user**](docs/MainApi.md#patch_user) | **PATCH** `/api/2/users/{id}` | 
+*MainApi* | [**patch_workstation**](docs/MainApi.md#patch_workstation) | **PATCH** `/api/2/workstations/{id}` | 
+*MainApi* | [**preview_user**](docs/MainApi.md#preview_user) | **POST** `/api/2/users/preview` | 
+*MainApi* | [**reboot**](docs/MainApi.md#reboot) | **POST** `/api/2/system/reboot` | 
+*MainApi* | [**register_upload**](docs/MainApi.md#register_upload) | **POST** `/api/2/uploads/register` | 
+*MainApi* | [**register_upload_metadata**](docs/MainApi.md#register_upload_metadata) | **POST** `/api/2/uploads/metadata` | 
+*MainApi* | [**render_email_template_preview**](docs/MainApi.md#render_email_template_preview) | **POST** `/api/2/system/smtp/preview` | 
+*MainApi* | [**reset_user_password**](docs/MainApi.md#reset_user_password) | **POST** `/api/2/users/{id}/password/reset` | 
+*MainApi* | [**restart_web_ui**](docs/MainApi.md#restart_web_ui) | **POST** `/api/2/system/restart-webui` | 
+*MainApi* | [**run_service_operation**](docs/MainApi.md#run_service_operation) | **POST** `/api/2/nodes/{id}/services/{service}/{operation}` | 
+*MainApi* | [**set_ipmi_configuration**](docs/MainApi.md#set_ipmi_configuration) | **PUT** `/api/2/nodes/{id}/ipmi` | 
+*MainApi* | [**set_local_time**](docs/MainApi.md#set_local_time) | **POST** `/api/2/system/time` | 
+*MainApi* | [**set_my_password**](docs/MainApi.md#set_my_password) | **POST** `/api/2/users/me/password` | 
+*MainApi* | [**set_user_password**](docs/MainApi.md#set_user_password) | **POST** `/api/2/users/{id}/password` | 
+*MainApi* | [**shutdown**](docs/MainApi.md#shutdown) | **POST** `/api/2/system/shutdown` | 
+*MainApi* | [**start_solr_reindex**](docs/MainApi.md#start_solr_reindex) | **POST** `/api/2/system/solr/reindex` | 
+*MainApi* | [**start_support_session**](docs/MainApi.md#start_support_session) | **POST** `/api/2/system/support-session/start` | 
+*MainApi* | [**start_system_backup**](docs/MainApi.md#start_system_backup) | **POST** `/api/2/system/backup/start` | 
+*MainApi* | [**sync_ldap_group**](docs/MainApi.md#sync_ldap_group) | **POST** `/api/2/groups/{id}/ldap-sync` | 
+*MainApi* | [**sync_ldap_users**](docs/MainApi.md#sync_ldap_users) | **POST** `/api/2/ldap-servers/{id}/sync-users` | 
+*MainApi* | [**sync_time**](docs/MainApi.md#sync_time) | **POST** `/api/2/system/time/sync` | 
+*MainApi* | [**sync_user_totp**](docs/MainApi.md#sync_user_totp) | **PUT** `/api/2/users/{id}/totp` | 
+*MainApi* | [**test_cloud_account_credentials**](docs/MainApi.md#test_cloud_account_credentials) | **POST** `/api/2/cloud/accounts/test-credentials` | 
+*MainApi* | [**test_smtp_configuration**](docs/MainApi.md#test_smtp_configuration) | **POST** `/api/2/system/smtp/test` | 
+*MainApi* | [**update_certificate_configuration**](docs/MainApi.md#update_certificate_configuration) | **PUT** `/api/2/system/certificate` | 
+*MainApi* | [**update_cloud_account**](docs/MainApi.md#update_cloud_account) | **PUT** `/api/2/cloud/accounts/{id}` | 
+*MainApi* | [**update_current_workstation**](docs/MainApi.md#update_current_workstation) | **PUT** `/api/2/workstations/current` | 
+*MainApi* | [**update_download_archive**](docs/MainApi.md#update_download_archive) | **PUT** `/api/2/download-archive/{id}` | 
+*MainApi* | [**update_filesystem_permission**](docs/MainApi.md#update_filesystem_permission) | **PUT** `/api/2/filesystem-permissions/{id}` | 
+*MainApi* | [**update_group**](docs/MainApi.md#update_group) | **PUT** `/api/2/groups/{id}` | 
+*MainApi* | [**update_ntp_server**](docs/MainApi.md#update_ntp_server) | **PUT** `/api/2/system/time/servers/{id}` | 
+*MainApi* | [**update_parameters**](docs/MainApi.md#update_parameters) | **PUT** `/api/2/parameters` | 
+*MainApi* | [**update_profile**](docs/MainApi.md#update_profile) | **PUT** `/api/2/users/me` | 
+*MainApi* | [**update_smtp_configuration**](docs/MainApi.md#update_smtp_configuration) | **PUT** `/api/2/system/smtp` | 
+*MainApi* | [**update_user**](docs/MainApi.md#update_user) | **PUT** `/api/2/users/{id}` | 
+*MainApi* | [**update_workstation**](docs/MainApi.md#update_workstation) | **PUT** `/api/2/workstations/{id}` | 
+*MainApi* | [**upload_chunk**](docs/MainApi.md#upload_chunk) | **POST** `/api/2/uploads/chunk` | 
+*MediaLibraryApi* | [**bookmark_media_directory**](docs/MediaLibraryApi.md#bookmark_media_directory) | **POST** `/api/2/media/files/{id}/bookmark` | 
+*MediaLibraryApi* | [**clear_subclip_clipboard**](docs/MediaLibraryApi.md#clear_subclip_clipboard) | **DELETE** `/api/2/media/subclips/clipboard/clear` | 
+*MediaLibraryApi* | [**clear_subtitle_clipboard**](docs/MediaLibraryApi.md#clear_subtitle_clipboard) | **DELETE** `/api/2/media/subtitles/clipboard/clear` | 
+*MediaLibraryApi* | [**combine_assets_into_set**](docs/MediaLibraryApi.md#combine_assets_into_set) | **POST** `/api/2/media/assets/combine` | 
+*MediaLibraryApi* | [**create_asset**](docs/MediaLibraryApi.md#create_asset) | **POST** `/api/2/media/assets` | 
+*MediaLibraryApi* | [**create_asset_rating**](docs/MediaLibraryApi.md#create_asset_rating) | **POST** `/api/2/media/ratings` | 
+*MediaLibraryApi* | [**create_asset_subtitle_link**](docs/MediaLibraryApi.md#create_asset_subtitle_link) | **POST** `/api/2/media/assets/subtitle-links` | 
+*MediaLibraryApi* | [**create_comment**](docs/MediaLibraryApi.md#create_comment) | **POST** `/api/2/media/comments` | 
+*MediaLibraryApi* | [**create_custom_field**](docs/MediaLibraryApi.md#create_custom_field) | **POST** `/api/2/media/custom-fields` | 
+*MediaLibraryApi* | [**create_editor_project**](docs/MediaLibraryApi.md#create_editor_project) | **POST** `/api/2/media/editor` | 
+*MediaLibraryApi* | [**create_editor_subtitle**](docs/MediaLibraryApi.md#create_editor_subtitle) | **POST** `/api/2/media/subtitles` | 
+*MediaLibraryApi* | [**create_external_transcoder**](docs/MediaLibraryApi.md#create_external_transcoder) | **POST** `/api/2/media/external-transcoders` | 
+*MediaLibraryApi* | [**create_marker**](docs/MediaLibraryApi.md#create_marker) | **POST** `/api/2/media/markers` | 
+*MediaLibraryApi* | [**create_media_file_template**](docs/MediaLibraryApi.md#create_media_file_template) | **POST** `/api/2/media/files/templates` | 
+*MediaLibraryApi* | [**create_media_root**](docs/MediaLibraryApi.md#create_media_root) | **POST** `/api/2/media/roots` | 
+*MediaLibraryApi* | [**create_media_root_permission**](docs/MediaLibraryApi.md#create_media_root_permission) | **POST** `/api/2/media/root-permissions` | 
+*MediaLibraryApi* | [**create_media_tag**](docs/MediaLibraryApi.md#create_media_tag) | **POST** `/api/2/media/tags` | 
+*MediaLibraryApi* | [**create_proxy_profile**](docs/MediaLibraryApi.md#create_proxy_profile) | **POST** `/api/2/media/proxy-profiles` | 
+*MediaLibraryApi* | [**create_saved_search**](docs/MediaLibraryApi.md#create_saved_search) | **POST** `/api/2/media/saved-searches` | 
+*MediaLibraryApi* | [**create_subclip**](docs/MediaLibraryApi.md#create_subclip) | **POST** `/api/2/media/subclips` | 
+*MediaLibraryApi* | [**create_subclip_clipboard_entry**](docs/MediaLibraryApi.md#create_subclip_clipboard_entry) | **POST** `/api/2/media/subclips/clipboard` | 
+*MediaLibraryApi* | [**create_subtitle_clipboard_entry**](docs/MediaLibraryApi.md#create_subtitle_clipboard_entry) | **POST** `/api/2/media/subtitles/clipboard` | 
+*MediaLibraryApi* | [**delete_asset**](docs/MediaLibraryApi.md#delete_asset) | **DELETE** `/api/2/media/assets/{id}` | 
+*MediaLibraryApi* | [**delete_asset_rating**](docs/MediaLibraryApi.md#delete_asset_rating) | **DELETE** `/api/2/media/ratings/{id}` | 
+*MediaLibraryApi* | [**delete_asset_subtitle_link**](docs/MediaLibraryApi.md#delete_asset_subtitle_link) | **DELETE** `/api/2/media/assets/subtitle-links/{id}` | 
+*MediaLibraryApi* | [**delete_comment**](docs/MediaLibraryApi.md#delete_comment) | **DELETE** `/api/2/media/comments/{id}` | 
+*MediaLibraryApi* | [**delete_custom_field**](docs/MediaLibraryApi.md#delete_custom_field) | **DELETE** `/api/2/media/custom-fields/{id}` | 
+*MediaLibraryApi* | [**delete_easy_sharing_token_for_bundle**](docs/MediaLibraryApi.md#delete_easy_sharing_token_for_bundle) | **DELETE** `/api/2/media/bundles/{id}/easy-sharing-token` | 
+*MediaLibraryApi* | [**delete_easy_sharing_token_for_directory**](docs/MediaLibraryApi.md#delete_easy_sharing_token_for_directory) | **DELETE** `/api/2/media/files/{id}/easy-sharing-token` | 
+*MediaLibraryApi* | [**delete_external_transcoder**](docs/MediaLibraryApi.md#delete_external_transcoder) | **DELETE** `/api/2/media/external-transcoders/{id}` | 
+*MediaLibraryApi* | [**delete_marker**](docs/MediaLibraryApi.md#delete_marker) | **DELETE** `/api/2/media/markers/{id}` | 
+*MediaLibraryApi* | [**delete_media_file_template**](docs/MediaLibraryApi.md#delete_media_file_template) | **DELETE** `/api/2/media/files/templates/{id}` | 
+*MediaLibraryApi* | [**delete_media_library_objects**](docs/MediaLibraryApi.md#delete_media_library_objects) | **POST** `/api/2/media/delete` | 
+*MediaLibraryApi* | [**delete_media_root**](docs/MediaLibraryApi.md#delete_media_root) | **DELETE** `/api/2/media/roots/{id}` | 
+*MediaLibraryApi* | [**delete_media_root_permission**](docs/MediaLibraryApi.md#delete_media_root_permission) | **DELETE** `/api/2/media/root-permissions/{id}` | 
+*MediaLibraryApi* | [**delete_media_tag**](docs/MediaLibraryApi.md#delete_media_tag) | **DELETE** `/api/2/media/tags/{id}` | 
+*MediaLibraryApi* | [**delete_media_update**](docs/MediaLibraryApi.md#delete_media_update) | **DELETE** `/api/2/media/updates/{id}` | 
+*MediaLibraryApi* | [**delete_proxy**](docs/MediaLibraryApi.md#delete_proxy) | **DELETE** `/api/2/media/proxies/{id}` | 
+*MediaLibraryApi* | [**delete_proxy_profile**](docs/MediaLibraryApi.md#delete_proxy_profile) | **DELETE** `/api/2/media/proxy-profiles/{id}` | 
+*MediaLibraryApi* | [**delete_saved_search**](docs/MediaLibraryApi.md#delete_saved_search) | **DELETE** `/api/2/media/saved-searches/{id}` | 
+*MediaLibraryApi* | [**delete_subclip**](docs/MediaLibraryApi.md#delete_subclip) | **DELETE** `/api/2/media/subclips/{id}` | 
+*MediaLibraryApi* | [**delete_subclip_clipboard_entry**](docs/MediaLibraryApi.md#delete_subclip_clipboard_entry) | **DELETE** `/api/2/media/subclips/clipboard/{id}` | 
+*MediaLibraryApi* | [**delete_subtitle_clipboard_entry**](docs/MediaLibraryApi.md#delete_subtitle_clipboard_entry) | **DELETE** `/api/2/media/subtitles/clipboard/{id}` | 
+*MediaLibraryApi* | [**discover_media**](docs/MediaLibraryApi.md#discover_media) | **POST** `/api/2/scanner/discover` | 
+*MediaLibraryApi* | [**download_asset_proxy_file**](docs/MediaLibraryApi.md#download_asset_proxy_file) | **GET** `/api/2/media/assets/{id}/proxy-files/{filename}` | 
+*MediaLibraryApi* | [**download_media_file**](docs/MediaLibraryApi.md#download_media_file) | **GET** `/api/2/media/files/{id}/download` | 
+*MediaLibraryApi* | [**download_proxy**](docs/MediaLibraryApi.md#download_proxy) | **GET** `/api/2/media/proxies/{id}/download` | 
+*MediaLibraryApi* | [**editor_export_xml_for_assset**](docs/MediaLibraryApi.md#editor_export_xml_for_assset) | **GET** `/api/2/media/editor/asset/{asset_ids}/xml-export` | 
+*MediaLibraryApi* | [**editor_export_xml_for_bundle**](docs/MediaLibraryApi.md#editor_export_xml_for_bundle) | **GET** `/api/2/media/editor/bundle/{bundle_ids}/xml-export` | 
+*MediaLibraryApi* | [**editor_export_xml_for_project**](docs/MediaLibraryApi.md#editor_export_xml_for_project) | **GET** `/api/2/media/editor/{id}/xml-export` | 
+*MediaLibraryApi* | [**export_comments_for_avid**](docs/MediaLibraryApi.md#export_comments_for_avid) | **GET** `/api/2/media/editor/asset/{asset_id}/{export_format}-export/avid-comments` | 
+*MediaLibraryApi* | [**export_editor_timeline**](docs/MediaLibraryApi.md#export_editor_timeline) | **POST** `/api/2/media/editor/timeline-export` | 
+*MediaLibraryApi* | [**extract_stream**](docs/MediaLibraryApi.md#extract_stream) | **POST** `/api/2/media/assets/{id}/extract-stream` | 
+*MediaLibraryApi* | [**forget_deleted_media_files**](docs/MediaLibraryApi.md#forget_deleted_media_files) | **POST** `/api/2/media/files/{id}/forget-deleted` | 
+*MediaLibraryApi* | [**generate_proxies**](docs/MediaLibraryApi.md#generate_proxies) | **POST** `/api/2/media/proxies` | 
+*MediaLibraryApi* | [**get_all_asset_project_links**](docs/MediaLibraryApi.md#get_all_asset_project_links) | **GET** `/api/2/media/assets/project-links` | 
+*MediaLibraryApi* | [**get_all_asset_ratings**](docs/MediaLibraryApi.md#get_all_asset_ratings) | **GET** `/api/2/media/ratings` | 
+*MediaLibraryApi* | [**get_all_asset_subtitle_links**](docs/MediaLibraryApi.md#get_all_asset_subtitle_links) | **GET** `/api/2/media/assets/subtitle-links` | 
+*MediaLibraryApi* | [**get_all_asset_tape_backups**](docs/MediaLibraryApi.md#get_all_asset_tape_backups) | **GET** `/api/2/media/backups` | 
+*MediaLibraryApi* | [**get_all_assets**](docs/MediaLibraryApi.md#get_all_assets) | **GET** `/api/2/media/assets` | 
+*MediaLibraryApi* | [**get_all_bundles_for_media_root**](docs/MediaLibraryApi.md#get_all_bundles_for_media_root) | **GET** `/api/2/media/bundles/flat/{root}` | 
+*MediaLibraryApi* | [**get_all_bundles_in_subtree**](docs/MediaLibraryApi.md#get_all_bundles_in_subtree) | **GET** `/api/2/media/bundles/flat/subtree/{file}` | 
+*MediaLibraryApi* | [**get_all_click_links**](docs/MediaLibraryApi.md#get_all_click_links) | **GET** `/api/2/media/assets/click-links` | 
+*MediaLibraryApi* | [**get_all_comments**](docs/MediaLibraryApi.md#get_all_comments) | **GET** `/api/2/media/comments` | 
+*MediaLibraryApi* | [**get_all_custom_fields**](docs/MediaLibraryApi.md#get_all_custom_fields) | **GET** `/api/2/media/custom-fields` | 
+*MediaLibraryApi* | [**get_all_external_transcoders**](docs/MediaLibraryApi.md#get_all_external_transcoders) | **GET** `/api/2/media/external-transcoders` | 
+*MediaLibraryApi* | [**get_all_markers**](docs/MediaLibraryApi.md#get_all_markers) | **GET** `/api/2/media/markers` | 
+*MediaLibraryApi* | [**get_all_media_file_bundles**](docs/MediaLibraryApi.md#get_all_media_file_bundles) | **GET** `/api/2/media/bundles` | 
+*MediaLibraryApi* | [**get_all_media_file_templates**](docs/MediaLibraryApi.md#get_all_media_file_templates) | **GET** `/api/2/media/files/templates` | 
+*MediaLibraryApi* | [**get_all_media_files**](docs/MediaLibraryApi.md#get_all_media_files) | **GET** `/api/2/media/files` | 
+*MediaLibraryApi* | [**get_all_media_files_for_bundles**](docs/MediaLibraryApi.md#get_all_media_files_for_bundles) | **POST** `/api/2/media/files/for-bundles` | 
+*MediaLibraryApi* | [**get_all_media_files_for_media_root**](docs/MediaLibraryApi.md#get_all_media_files_for_media_root) | **GET** `/api/2/media/files/flat/{root}` | 
+*MediaLibraryApi* | [**get_all_media_files_in_subtree**](docs/MediaLibraryApi.md#get_all_media_files_in_subtree) | **GET** `/api/2/media/files/flat/subtree/{file}` | 
+*MediaLibraryApi* | [**get_all_media_root_permissions**](docs/MediaLibraryApi.md#get_all_media_root_permissions) | **GET** `/api/2/media/root-permissions` | 
+*MediaLibraryApi* | [**get_all_media_roots**](docs/MediaLibraryApi.md#get_all_media_roots) | **GET** `/api/2/media/roots` | 
+*MediaLibraryApi* | [**get_all_media_tags**](docs/MediaLibraryApi.md#get_all_media_tags) | **GET** `/api/2/media/tags` | 
+*MediaLibraryApi* | [**get_all_media_updates**](docs/MediaLibraryApi.md#get_all_media_updates) | **GET** `/api/2/media/updates` | 
+*MediaLibraryApi* | [**get_all_proxy_generators**](docs/MediaLibraryApi.md#get_all_proxy_generators) | **GET** `/api/2/media/proxy-generators` | 
+*MediaLibraryApi* | [**get_all_proxy_profiles**](docs/MediaLibraryApi.md#get_all_proxy_profiles) | **GET** `/api/2/media/proxy-profiles` | 
+*MediaLibraryApi* | [**get_all_saved_searches**](docs/MediaLibraryApi.md#get_all_saved_searches) | **GET** `/api/2/media/saved-searches` | 
+*MediaLibraryApi* | [**get_all_subclip_clipboard_entries**](docs/MediaLibraryApi.md#get_all_subclip_clipboard_entries) | **GET** `/api/2/media/subclips/clipboard` | 
+*MediaLibraryApi* | [**get_all_subclips**](docs/MediaLibraryApi.md#get_all_subclips) | **GET** `/api/2/media/subclips` | 
+*MediaLibraryApi* | [**get_all_subtitle_clipboard_entries**](docs/MediaLibraryApi.md#get_all_subtitle_clipboard_entries) | **GET** `/api/2/media/subtitles/clipboard` | 
+*MediaLibraryApi* | [**get_all_transcoder_profiles**](docs/MediaLibraryApi.md#get_all_transcoder_profiles) | **GET** `/api/2/transcoder-profiles` | 
+*MediaLibraryApi* | [**get_asset**](docs/MediaLibraryApi.md#get_asset) | **GET** `/api/2/media/assets/{id}` | 
+*MediaLibraryApi* | [**get_asset_rating**](docs/MediaLibraryApi.md#get_asset_rating) | **GET** `/api/2/media/ratings/{id}` | 
+*MediaLibraryApi* | [**get_asset_subtitle_link**](docs/MediaLibraryApi.md#get_asset_subtitle_link) | **GET** `/api/2/media/assets/subtitle-links/{id}` | 
+*MediaLibraryApi* | [**get_bookmarked_media_files_directories**](docs/MediaLibraryApi.md#get_bookmarked_media_files_directories) | **GET** `/api/2/media/files/bookmarks` | 
+*MediaLibraryApi* | [**get_comment**](docs/MediaLibraryApi.md#get_comment) | **GET** `/api/2/media/comments/{id}` | 
+*MediaLibraryApi* | [**get_custom_field**](docs/MediaLibraryApi.md#get_custom_field) | **GET** `/api/2/media/custom-fields/{id}` | 
+*MediaLibraryApi* | [**get_easy_sharing_token_for_bundle**](docs/MediaLibraryApi.md#get_easy_sharing_token_for_bundle) | **GET** `/api/2/media/bundles/{id}/easy-sharing-token` | 
+*MediaLibraryApi* | [**get_easy_sharing_token_for_directory**](docs/MediaLibraryApi.md#get_easy_sharing_token_for_directory) | **GET** `/api/2/media/files/{id}/easy-sharing-token` | 
+*MediaLibraryApi* | [**get_editor_project**](docs/MediaLibraryApi.md#get_editor_project) | **GET** `/api/2/media/editor/{id}` | 
+*MediaLibraryApi* | [**get_editor_subtitle**](docs/MediaLibraryApi.md#get_editor_subtitle) | **GET** `/api/2/media/subtitles/{id}` | 
+*MediaLibraryApi* | [**get_external_transcoder**](docs/MediaLibraryApi.md#get_external_transcoder) | **GET** `/api/2/media/external-transcoders/{id}` | 
+*MediaLibraryApi* | [**get_frame**](docs/MediaLibraryApi.md#get_frame) | **GET** `/api/2/media/assets/{id}/frames/{frame}` | 
+*MediaLibraryApi* | [**get_latest_media_update**](docs/MediaLibraryApi.md#get_latest_media_update) | **GET** `/api/2/media/updates/latest` | 
+*MediaLibraryApi* | [**get_marker**](docs/MediaLibraryApi.md#get_marker) | **GET** `/api/2/media/markers/{id}` | 
+*MediaLibraryApi* | [**get_media_file**](docs/MediaLibraryApi.md#get_media_file) | **GET** `/api/2/media/files/{id}` | 
+*MediaLibraryApi* | [**get_media_file_bundle**](docs/MediaLibraryApi.md#get_media_file_bundle) | **GET** `/api/2/media/bundles/{id}` | 
+*MediaLibraryApi* | [**get_media_file_contents**](docs/MediaLibraryApi.md#get_media_file_contents) | **GET** `/api/2/media/files/{id}/contents` | 
+*MediaLibraryApi* | [**get_media_file_template**](docs/MediaLibraryApi.md#get_media_file_template) | **GET** `/api/2/media/files/templates/{id}` | 
+*MediaLibraryApi* | [**get_media_root**](docs/MediaLibraryApi.md#get_media_root) | **GET** `/api/2/media/roots/{id}` | 
+*MediaLibraryApi* | [**get_media_root_permission**](docs/MediaLibraryApi.md#get_media_root_permission) | **GET** `/api/2/media/root-permissions/{id}` | 
+*MediaLibraryApi* | [**get_media_tag**](docs/MediaLibraryApi.md#get_media_tag) | **GET** `/api/2/media/tags/{id}` | 
+*MediaLibraryApi* | [**get_multiple_assets**](docs/MediaLibraryApi.md#get_multiple_assets) | **POST** `/api/2/media/assets/multiple` | 
+*MediaLibraryApi* | [**get_multiple_bundles**](docs/MediaLibraryApi.md#get_multiple_bundles) | **POST** `/api/2/media/bundles/multiple` | 
+*MediaLibraryApi* | [**get_multiple_files**](docs/MediaLibraryApi.md#get_multiple_files) | **POST** `/api/2/media/files/multiple` | 
+*MediaLibraryApi* | [**get_my_media_root_permissions**](docs/MediaLibraryApi.md#get_my_media_root_permissions) | **GET** `/api/2/media/root-permissions/mine` | 
+*MediaLibraryApi* | [**get_my_resolved_media_root_permissions**](docs/MediaLibraryApi.md#get_my_resolved_media_root_permissions) | **GET** `/api/2/media/root-permissions/mine/resolved` | 
+*MediaLibraryApi* | [**get_proxy**](docs/MediaLibraryApi.md#get_proxy) | **GET** `/api/2/media/proxies/{id}` | 
+*MediaLibraryApi* | [**get_proxy_generator**](docs/MediaLibraryApi.md#get_proxy_generator) | **GET** `/api/2/media/proxy-generators/{id}` | 
+*MediaLibraryApi* | [**get_proxy_profile**](docs/MediaLibraryApi.md#get_proxy_profile) | **GET** `/api/2/media/proxy-profiles/{id}` | 
+*MediaLibraryApi* | [**get_proxy_profile_proxy_count**](docs/MediaLibraryApi.md#get_proxy_profile_proxy_count) | **GET** `/api/2/media/proxy-profiles/{id}/proxy-count` | 
+*MediaLibraryApi* | [**get_saved_search**](docs/MediaLibraryApi.md#get_saved_search) | **GET** `/api/2/media/saved-searches/{id}` | 
+*MediaLibraryApi* | [**get_subclip**](docs/MediaLibraryApi.md#get_subclip) | **GET** `/api/2/media/subclips/{id}` | 
+*MediaLibraryApi* | [**get_subtitles**](docs/MediaLibraryApi.md#get_subtitles) | **GET** `/api/2/media/assets/{id}/subtitle/{title}` | 
+*MediaLibraryApi* | [**get_transcoder_profile**](docs/MediaLibraryApi.md#get_transcoder_profile) | **GET** `/api/2/transcoder-profiles/{id}` | 
+*MediaLibraryApi* | [**get_vantage_workflows**](docs/MediaLibraryApi.md#get_vantage_workflows) | **GET** `/api/2/media/external-transcoders/{id}/workflows` | 
+*MediaLibraryApi* | [**instantiate_media_file_template**](docs/MediaLibraryApi.md#instantiate_media_file_template) | **POST** `/api/2/media/files/templates/{id}/instantiate` | 
+*MediaLibraryApi* | [**locate_editor_project_paths**](docs/MediaLibraryApi.md#locate_editor_project_paths) | **GET** `/api/2/media/editor/{id}/locate-paths` | 
+*MediaLibraryApi* | [**lookup_media_files**](docs/MediaLibraryApi.md#lookup_media_files) | **POST** `/api/2/media/files/lookup` | 
+*MediaLibraryApi* | [**mark_media_directory_as_showroom**](docs/MediaLibraryApi.md#mark_media_directory_as_showroom) | **POST** `/api/2/media/files/{id}/showroom` | 
+*MediaLibraryApi* | [**patch_asset**](docs/MediaLibraryApi.md#patch_asset) | **PATCH** `/api/2/media/assets/{id}` | 
+*MediaLibraryApi* | [**patch_asset_rating**](docs/MediaLibraryApi.md#patch_asset_rating) | **PATCH** `/api/2/media/ratings/{id}` | 
+*MediaLibraryApi* | [**patch_asset_subtitle_link**](docs/MediaLibraryApi.md#patch_asset_subtitle_link) | **PATCH** `/api/2/media/assets/subtitle-links/{id}` | 
+*MediaLibraryApi* | [**patch_comment**](docs/MediaLibraryApi.md#patch_comment) | **PATCH** `/api/2/media/comments/{id}` | 
+*MediaLibraryApi* | [**patch_custom_field**](docs/MediaLibraryApi.md#patch_custom_field) | **PATCH** `/api/2/media/custom-fields/{id}` | 
+*MediaLibraryApi* | [**patch_editor_project**](docs/MediaLibraryApi.md#patch_editor_project) | **PATCH** `/api/2/media/editor/{id}` | 
+*MediaLibraryApi* | [**patch_editor_subtitle**](docs/MediaLibraryApi.md#patch_editor_subtitle) | **PATCH** `/api/2/media/subtitles/{id}` | 
+*MediaLibraryApi* | [**patch_external_transcoder**](docs/MediaLibraryApi.md#patch_external_transcoder) | **PATCH** `/api/2/media/external-transcoders/{id}` | 
+*MediaLibraryApi* | [**patch_marker**](docs/MediaLibraryApi.md#patch_marker) | **PATCH** `/api/2/media/markers/{id}` | 
+*MediaLibraryApi* | [**patch_media_file**](docs/MediaLibraryApi.md#patch_media_file) | **PATCH** `/api/2/media/files/{id}` | 
+*MediaLibraryApi* | [**patch_media_file_template**](docs/MediaLibraryApi.md#patch_media_file_template) | **PATCH** `/api/2/media/files/templates/{id}` | 
+*MediaLibraryApi* | [**patch_media_root**](docs/MediaLibraryApi.md#patch_media_root) | **PATCH** `/api/2/media/roots/{id}` | 
+*MediaLibraryApi* | [**patch_media_root_permission**](docs/MediaLibraryApi.md#patch_media_root_permission) | **PATCH** `/api/2/media/root-permissions/{id}` | 
+*MediaLibraryApi* | [**patch_media_tag**](docs/MediaLibraryApi.md#patch_media_tag) | **PATCH** `/api/2/media/tags/{id}` | 
+*MediaLibraryApi* | [**patch_proxy_profile**](docs/MediaLibraryApi.md#patch_proxy_profile) | **PATCH** `/api/2/media/proxy-profiles/{id}` | 
+*MediaLibraryApi* | [**patch_saved_search**](docs/MediaLibraryApi.md#patch_saved_search) | **PATCH** `/api/2/media/saved-searches/{id}` | 
+*MediaLibraryApi* | [**patch_subclip**](docs/MediaLibraryApi.md#patch_subclip) | **PATCH** `/api/2/media/subclips/{id}` | 
+*MediaLibraryApi* | [**recursively_tag_media_directory**](docs/MediaLibraryApi.md#recursively_tag_media_directory) | **POST** `/api/2/media/files/{id}/tag` | 
+*MediaLibraryApi* | [**reindex_media_directory**](docs/MediaLibraryApi.md#reindex_media_directory) | **POST** `/api/2/media/files/{id}/search-reindex` | 
+*MediaLibraryApi* | [**rename_custom_field**](docs/MediaLibraryApi.md#rename_custom_field) | **POST** `/api/2/media/custom-fields/{id}/rename` | 
+*MediaLibraryApi* | [**render_sequence**](docs/MediaLibraryApi.md#render_sequence) | **POST** `/api/2/media/editor/render` | 
+*MediaLibraryApi* | [**render_subclip**](docs/MediaLibraryApi.md#render_subclip) | **POST** `/api/2/media/subclips/{id}/render` | 
+*MediaLibraryApi* | [**request_media_scan**](docs/MediaLibraryApi.md#request_media_scan) | **POST** `/api/2/scanner/scan` | 
+*MediaLibraryApi* | [**resolve_comment**](docs/MediaLibraryApi.md#resolve_comment) | **POST** `/api/2/media/comments/{id}/resolve` | 
+*MediaLibraryApi* | [**share_media_library_objects**](docs/MediaLibraryApi.md#share_media_library_objects) | **POST** `/api/2/media/share` | 
+*MediaLibraryApi* | [**test_external_transcoder_connection**](docs/MediaLibraryApi.md#test_external_transcoder_connection) | **POST** `/api/2/media/external-transcoders/test-connection` | 
+*MediaLibraryApi* | [**transition_workflow**](docs/MediaLibraryApi.md#transition_workflow) | **POST** `/api/2/media/workflow/transition` | 
+*MediaLibraryApi* | [**unbookmark_media_directory**](docs/MediaLibraryApi.md#unbookmark_media_directory) | **DELETE** `/api/2/media/files/{id}/bookmark` | 
+*MediaLibraryApi* | [**unmark_media_directory_as_showroom**](docs/MediaLibraryApi.md#unmark_media_directory_as_showroom) | **DELETE** `/api/2/media/files/{id}/showroom` | 
+*MediaLibraryApi* | [**unresolve_comment**](docs/MediaLibraryApi.md#unresolve_comment) | **POST** `/api/2/media/comments/{id}/unresolve` | 
+*MediaLibraryApi* | [**update_asset**](docs/MediaLibraryApi.md#update_asset) | **PUT** `/api/2/media/assets/{id}` | 
+*MediaLibraryApi* | [**update_asset_rating**](docs/MediaLibraryApi.md#update_asset_rating) | **PUT** `/api/2/media/ratings/{id}` | 
+*MediaLibraryApi* | [**update_asset_subtitle_link**](docs/MediaLibraryApi.md#update_asset_subtitle_link) | **PUT** `/api/2/media/assets/subtitle-links/{id}` | 
+*MediaLibraryApi* | [**update_comment**](docs/MediaLibraryApi.md#update_comment) | **PUT** `/api/2/media/comments/{id}` | 
+*MediaLibraryApi* | [**update_custom_field**](docs/MediaLibraryApi.md#update_custom_field) | **PUT** `/api/2/media/custom-fields/{id}` | 
+*MediaLibraryApi* | [**update_editor_project**](docs/MediaLibraryApi.md#update_editor_project) | **PUT** `/api/2/media/editor/{id}` | 
+*MediaLibraryApi* | [**update_editor_subtitle**](docs/MediaLibraryApi.md#update_editor_subtitle) | **PUT** `/api/2/media/subtitles/{id}` | 
+*MediaLibraryApi* | [**update_external_transcoder**](docs/MediaLibraryApi.md#update_external_transcoder) | **PUT** `/api/2/media/external-transcoders/{id}` | 
+*MediaLibraryApi* | [**update_marker**](docs/MediaLibraryApi.md#update_marker) | **PUT** `/api/2/media/markers/{id}` | 
+*MediaLibraryApi* | [**update_media_file**](docs/MediaLibraryApi.md#update_media_file) | **PUT** `/api/2/media/files/{id}` | 
+*MediaLibraryApi* | [**update_media_file_template**](docs/MediaLibraryApi.md#update_media_file_template) | **PUT** `/api/2/media/files/templates/{id}` | 
+*MediaLibraryApi* | [**update_media_root**](docs/MediaLibraryApi.md#update_media_root) | **PUT** `/api/2/media/roots/{id}` | 
+*MediaLibraryApi* | [**update_media_root_permission**](docs/MediaLibraryApi.md#update_media_root_permission) | **PUT** `/api/2/media/root-permissions/{id}` | 
+*MediaLibraryApi* | [**update_media_tag**](docs/MediaLibraryApi.md#update_media_tag) | **PUT** `/api/2/media/tags/{id}` | 
+*MediaLibraryApi* | [**update_proxy_profile**](docs/MediaLibraryApi.md#update_proxy_profile) | **PUT** `/api/2/media/proxy-profiles/{id}` | 
+*MediaLibraryApi* | [**update_saved_search**](docs/MediaLibraryApi.md#update_saved_search) | **PUT** `/api/2/media/saved-searches/{id}` | 
+*MediaLibraryApi* | [**update_subclip**](docs/MediaLibraryApi.md#update_subclip) | **PUT** `/api/2/media/subclips/{id}` | 
+*PrivateApi* | [**delete_stored_image**](docs/PrivateApi.md#delete_stored_image) | **DELETE** `/api/2/image/{name}` | 
+*PrivateApi* | [**delete_veritone_tdo**](docs/PrivateApi.md#delete_veritone_tdo) | **DELETE** `/api/2/veritone/connections/{id}/tdo/{tdo_id}` | 
+*PrivateApi* | [**export_non_proxied_assets**](docs/PrivateApi.md#export_non_proxied_assets) | **GET** `/api/2/private/export/non-proxied/{root_id}` | 
+*PrivateApi* | [**export_non_proxied_assets_for_path**](docs/PrivateApi.md#export_non_proxied_assets_for_path) | **GET** `/api/2/private/export/non-proxied/{root_id}/{path}` | 
+*PrivateApi* | [**export_updates**](docs/PrivateApi.md#export_updates) | **GET** `/api/2/private/export/updates/{root_id}` | 
+*PrivateApi* | [**get**](docs/PrivateApi.md#get) | **GET** `/api/2/private/bootstrap` | 
+*PrivateApi* | [**get_all_veritone_connections**](docs/PrivateApi.md#get_all_veritone_connections) | **GET** `/api/2/veritone/connections` | 
+*PrivateApi* | [**get_all_veritone_metadata**](docs/PrivateApi.md#get_all_veritone_metadata) | **GET** `/api/2/veritone/metadata` | 
+*PrivateApi* | [**get_client_side_url**](docs/PrivateApi.md#get_client_side_url) | **POST** `/api/2/private/client-side-url` | 
+*PrivateApi* | [**get_help_page**](docs/PrivateApi.md#get_help_page) | **GET** `/api/2/help/{id}` | 
+*PrivateApi* | [**get_locale**](docs/PrivateApi.md#get_locale) | **GET** `/api/2/private/locale/{lang}` | 
+*PrivateApi* | [**get_proxy_fs_size**](docs/PrivateApi.md#get_proxy_fs_size) | **GET** `/api/2/private/media/proxyfs-size` | 
+*PrivateApi* | [**get_stored_image**](docs/PrivateApi.md#get_stored_image) | **GET** `/api/2/image/{name}` | 
+*PrivateApi* | [**get_veritone_connection**](docs/PrivateApi.md#get_veritone_connection) | **GET** `/api/2/veritone/connections/{id}` | 
+*PrivateApi* | [**get_veritone_engines**](docs/PrivateApi.md#get_veritone_engines) | **GET** `/api/2/veritone/connections/{id}/engines` | 
+*PrivateApi* | [**get_veritone_jobs**](docs/PrivateApi.md#get_veritone_jobs) | **GET** `/api/2/veritone/connections/{id}/jobs` | 
+*PrivateApi* | [**get_veritone_metadata**](docs/PrivateApi.md#get_veritone_metadata) | **GET** `/api/2/veritone/metadata/{id}` | 
+*PrivateApi* | [**install_license**](docs/PrivateApi.md#install_license) | **POST** `/api/2/license/install` | 
+*PrivateApi* | [**language_server_request**](docs/PrivateApi.md#language_server_request) | **POST** `/api/2/language-server/{language}` | 
+*PrivateApi* | [**locate_file**](docs/PrivateApi.md#locate_file) | **POST** `/api/2/private/locate` | 
+*PrivateApi* | [**locate_proxies**](docs/PrivateApi.md#locate_proxies) | **POST** `/api/2/panel/locate-proxies` | 
+*PrivateApi* | [**upload_stored_image**](docs/PrivateApi.md#upload_stored_image) | **POST** `/api/2/private/images/upload` | 
+*PrivateApi* | [**upload_to_veritone**](docs/PrivateApi.md#upload_to_veritone) | **POST** `/api/2/veritone/connections/{id}/upload` | 
+*SatelliteApi* | [**activate_satellite_host**](docs/SatelliteApi.md#activate_satellite_host) | **POST** `/api/2/rdc/hosts/{id}/activate` | 
+*SatelliteApi* | [**announce_satellite_host**](docs/SatelliteApi.md#announce_satellite_host) | **POST** `/api/2/rdc/hosts/announce` | 
+*SatelliteApi* | [**create_satellite_session**](docs/SatelliteApi.md#create_satellite_session) | **POST** `/api/2/rdc/sessions` | 
+*SatelliteApi* | [**delete_satellite_session**](docs/SatelliteApi.md#delete_satellite_session) | **DELETE** `/api/2/rdc/sessions/{id}` | 
+*SatelliteApi* | [**get_all_satellite_hosts**](docs/SatelliteApi.md#get_all_satellite_hosts) | **GET** `/api/2/rdc/hosts` | 
+*SatelliteApi* | [**get_all_satellite_sessions**](docs/SatelliteApi.md#get_all_satellite_sessions) | **GET** `/api/2/rdc/sessions` | 
+*SatelliteApi* | [**get_satellite_host**](docs/SatelliteApi.md#get_satellite_host) | **GET** `/api/2/rdc/hosts/{id}` | 
+*SatelliteApi* | [**get_satellite_session**](docs/SatelliteApi.md#get_satellite_session) | **GET** `/api/2/rdc/sessions/{id}` | 
+*SharedstorageApi* | [**get_shared_storage_value**](docs/SharedstorageApi.md#get_shared_storage_value) | **GET** `/api/2/private/shared-storage/{name}` | 
+*SharedstorageApi* | [**get_user_storage_value**](docs/SharedstorageApi.md#get_user_storage_value) | **GET** `/api/2/private/user-storage/{name}` | 
+*SharedstorageApi* | [**set_shared_storage_value**](docs/SharedstorageApi.md#set_shared_storage_value) | **POST** `/api/2/private/shared-storage/{name}` | 
+*SharedstorageApi* | [**set_user_storage_value**](docs/SharedstorageApi.md#set_user_storage_value) | **POST** `/api/2/private/user-storage/{name}` | 
+*StatusApi* | [**get_alert**](docs/StatusApi.md#get_alert) | **GET** `/api/2/alerts/{id}` | 
+*StatusApi* | [**get_all_alerts**](docs/StatusApi.md#get_all_alerts) | **GET** `/api/2/alerts` | 
+*StatusApi* | [**get_telegraf_stats**](docs/StatusApi.md#get_telegraf_stats) | **GET** `/api/2/telegraf-stats` | 
+*StatusApi* | [**patch_alert**](docs/StatusApi.md#patch_alert) | **PATCH** `/api/2/alerts/{id}` | 
+*StatusApi* | [**submit_kapacitor_alert**](docs/StatusApi.md#submit_kapacitor_alert) | **POST** `/api/2/alerts/submit` | 
+*StatusApi* | [**update_alert**](docs/StatusApi.md#update_alert) | **PUT** `/api/2/alerts/{id}` | 
+*StorageApi* | [**apply_workspace_affinity**](docs/StorageApi.md#apply_workspace_affinity) | **POST** `/api/2/workspaces/{id}/apply-affinity` | 
+*StorageApi* | [**bookmark_workspace**](docs/StorageApi.md#bookmark_workspace) | **POST** `/api/2/workspaces/{id}/bookmark` | 
+*StorageApi* | [**calculate_directory_size**](docs/StorageApi.md#calculate_directory_size) | **POST** `/api/2/filesystem/calculate-directory-size` | 
+*StorageApi* | [**check_in_into_workspace**](docs/StorageApi.md#check_in_into_workspace) | **POST** `/api/2/workspaces/{id}/check-in` | 
+*StorageApi* | [**check_out_of_workspace**](docs/StorageApi.md#check_out_of_workspace) | **POST** `/api/2/workspaces/{id}/check-out` | 
+*StorageApi* | [**copy_files**](docs/StorageApi.md#copy_files) | **POST** `/api/2/filesystem/copy` | 
+*StorageApi* | [**create_file**](docs/StorageApi.md#create_file) | **POST** `/api/2/files` | 
+*StorageApi* | [**create_path_quota**](docs/StorageApi.md#create_path_quota) | **POST** `/api/2/volumes/{id}/quotas/path/{relative_path}` | 
+*StorageApi* | [**create_production**](docs/StorageApi.md#create_production) | **POST** `/api/2/productions` | 
+*StorageApi* | [**create_share**](docs/StorageApi.md#create_share) | **POST** `/api/2/shares` | 
+*StorageApi* | [**create_snapshot**](docs/StorageApi.md#create_snapshot) | **POST** `/api/2/snapshots` | 
+*StorageApi* | [**create_template_folder**](docs/StorageApi.md#create_template_folder) | **POST** `/api/2/private/create-template-folder` | 
+*StorageApi* | [**create_volume**](docs/StorageApi.md#create_volume) | **POST** `/api/2/volumes` | 
+*StorageApi* | [**create_workspace**](docs/StorageApi.md#create_workspace) | **POST** `/api/2/workspaces` | 
+*StorageApi* | [**create_workspace_permission**](docs/StorageApi.md#create_workspace_permission) | **POST** `/api/2/workspace-permissions` | 
+*StorageApi* | [**delete_file**](docs/StorageApi.md#delete_file) | **DELETE** `/api/2/files/{path}` | 
+*StorageApi* | [**delete_files**](docs/StorageApi.md#delete_files) | **POST** `/api/2/filesystem/delete` | 
+*StorageApi* | [**delete_path_quota**](docs/StorageApi.md#delete_path_quota) | **DELETE** `/api/2/volumes/{id}/quotas/path/{relative_path}` | 
+*StorageApi* | [**delete_production**](docs/StorageApi.md#delete_production) | **DELETE** `/api/2/productions/{id}` | 
+*StorageApi* | [**delete_share**](docs/StorageApi.md#delete_share) | **DELETE** `/api/2/shares/{id}` | 
+*StorageApi* | [**delete_snapshot**](docs/StorageApi.md#delete_snapshot) | **DELETE** `/api/2/snapshots/{id}` | 
+*StorageApi* | [**delete_workspace**](docs/StorageApi.md#delete_workspace) | **DELETE** `/api/2/workspaces/{id}` | 
+*StorageApi* | [**delete_workspace_permission**](docs/StorageApi.md#delete_workspace_permission) | **DELETE** `/api/2/workspace-permissions/{id}` | 
+*StorageApi* | [**get_all_deleted_workspaces**](docs/StorageApi.md#get_all_deleted_workspaces) | **GET** `/api/2/workspaces/deleted` | 
+*StorageApi* | [**get_all_productions**](docs/StorageApi.md#get_all_productions) | **GET** `/api/2/productions` | 
+*StorageApi* | [**get_all_shares**](docs/StorageApi.md#get_all_shares) | **GET** `/api/2/shares` | 
+*StorageApi* | [**get_all_snapshots**](docs/StorageApi.md#get_all_snapshots) | **GET** `/api/2/snapshots` | 
+*StorageApi* | [**get_all_volumes**](docs/StorageApi.md#get_all_volumes) | **GET** `/api/2/volumes` | 
+*StorageApi* | [**get_all_workspace_permissions**](docs/StorageApi.md#get_all_workspace_permissions) | **GET** `/api/2/workspace-permissions` | 
+*StorageApi* | [**get_all_workspaces**](docs/StorageApi.md#get_all_workspaces) | **GET** `/api/2/workspaces` | 
+*StorageApi* | [**get_file**](docs/StorageApi.md#get_file) | **GET** `/api/2/files/{path}` | 
+*StorageApi* | [**get_group_quota**](docs/StorageApi.md#get_group_quota) | **GET** `/api/2/volumes/{id}/quotas/group/{group_id}` | 
+*StorageApi* | [**get_my_workspaces**](docs/StorageApi.md#get_my_workspaces) | **GET** `/api/2/workspaces/mine` | 
+*StorageApi* | [**get_path_quota**](docs/StorageApi.md#get_path_quota) | **GET** `/api/2/volumes/{id}/quotas/path/{relative_path}` | 
+*StorageApi* | [**get_production**](docs/StorageApi.md#get_production) | **GET** `/api/2/productions/{id}` | 
+*StorageApi* | [**get_root_directory**](docs/StorageApi.md#get_root_directory) | **GET** `/api/2/files` | 
+*StorageApi* | [**get_samba_dfree_string**](docs/StorageApi.md#get_samba_dfree_string) | **POST** `/api/2/private/dfree` | 
+*StorageApi* | [**get_share**](docs/StorageApi.md#get_share) | **GET** `/api/2/shares/{id}` | 
+*StorageApi* | [**get_snapshot**](docs/StorageApi.md#get_snapshot) | **GET** `/api/2/snapshots/{id}` | 
+*StorageApi* | [**get_user_quota**](docs/StorageApi.md#get_user_quota) | **GET** `/api/2/volumes/{id}/quotas/user/{user_id}` | 
+*StorageApi* | [**get_volume**](docs/StorageApi.md#get_volume) | **GET** `/api/2/volumes/{id}` | 
+*StorageApi* | [**get_volume_active_connections**](docs/StorageApi.md#get_volume_active_connections) | **GET** `/api/2/volumes/{id}/connections` | 
+*StorageApi* | [**get_volume_file_size_distribution**](docs/StorageApi.md#get_volume_file_size_distribution) | **GET** `/api/2/volumes/{id}/file-size-distribution` | 
+*StorageApi* | [**get_volume_stats**](docs/StorageApi.md#get_volume_stats) | **GET** `/api/2/volumes/{id}/stats` | 
+*StorageApi* | [**get_workspace**](docs/StorageApi.md#get_workspace) | **GET** `/api/2/workspaces/{id}` | 
+*StorageApi* | [**get_workspace_permission**](docs/StorageApi.md#get_workspace_permission) | **GET** `/api/2/workspace-permissions/{id}` | 
+*StorageApi* | [**move_files**](docs/StorageApi.md#move_files) | **POST** `/api/2/filesystem/move` | 
+*StorageApi* | [**move_workspace**](docs/StorageApi.md#move_workspace) | **POST** `/api/2/workspaces/{id}/move` | 
+*StorageApi* | [**move_workspace_to_production**](docs/StorageApi.md#move_workspace_to_production) | **POST** `/api/2/workspaces/{id}/move-to` | 
+*StorageApi* | [**patch_file**](docs/StorageApi.md#patch_file) | **PATCH** `/api/2/files/{path}` | 
+*StorageApi* | [**patch_production**](docs/StorageApi.md#patch_production) | **PATCH** `/api/2/productions/{id}` | 
+*StorageApi* | [**patch_share**](docs/StorageApi.md#patch_share) | **PATCH** `/api/2/shares/{id}` | 
+*StorageApi* | [**patch_snapshot**](docs/StorageApi.md#patch_snapshot) | **PATCH** `/api/2/snapshots/{id}` | 
+*StorageApi* | [**patch_volume**](docs/StorageApi.md#patch_volume) | **PATCH** `/api/2/volumes/{id}` | 
+*StorageApi* | [**patch_workspace**](docs/StorageApi.md#patch_workspace) | **PATCH** `/api/2/workspaces/{id}` | 
+*StorageApi* | [**patch_workspace_permission**](docs/StorageApi.md#patch_workspace_permission) | **PATCH** `/api/2/workspace-permissions/{id}` | 
+*StorageApi* | [**record_storage_trace**](docs/StorageApi.md#record_storage_trace) | **POST** `/api/2/filesystem/trace` | 
+*StorageApi* | [**repair_workspace_permissions**](docs/StorageApi.md#repair_workspace_permissions) | **POST** `/api/2/workspaces/{id}/repair-permissions` | 
+*StorageApi* | [**share_to_home_workspace**](docs/StorageApi.md#share_to_home_workspace) | **POST** `/api/2/share-to-home-workspace` | 
+*StorageApi* | [**unbookmark_workspace**](docs/StorageApi.md#unbookmark_workspace) | **DELETE** `/api/2/workspaces/{id}/bookmark` | 
+*StorageApi* | [**unzip_file**](docs/StorageApi.md#unzip_file) | **POST** `/api/2/filesystem/unzip` | 
+*StorageApi* | [**update_group_quota**](docs/StorageApi.md#update_group_quota) | **PUT** `/api/2/volumes/{id}/quotas/group/{group_id}` | 
+*StorageApi* | [**update_path_quota**](docs/StorageApi.md#update_path_quota) | **PUT** `/api/2/volumes/{id}/quotas/path/{relative_path}` | 
+*StorageApi* | [**update_production**](docs/StorageApi.md#update_production) | **PUT** `/api/2/productions/{id}` | 
+*StorageApi* | [**update_share**](docs/StorageApi.md#update_share) | **PUT** `/api/2/shares/{id}` | 
+*StorageApi* | [**update_snapshot**](docs/StorageApi.md#update_snapshot) | **PUT** `/api/2/snapshots/{id}` | 
+*StorageApi* | [**update_user_quota**](docs/StorageApi.md#update_user_quota) | **PUT** `/api/2/volumes/{id}/quotas/user/{user_id}` | 
+*StorageApi* | [**update_volume**](docs/StorageApi.md#update_volume) | **PUT** `/api/2/volumes/{id}` | 
+*StorageApi* | [**update_workspace**](docs/StorageApi.md#update_workspace) | **PUT** `/api/2/workspaces/{id}` | 
+*StorageApi* | [**update_workspace_permission**](docs/StorageApi.md#update_workspace_permission) | **PUT** `/api/2/workspace-permissions/{id}` | 
+*StorageApi* | [**zip_files**](docs/StorageApi.md#zip_files) | **POST** `/api/2/filesystem/zip` | 
+*TapeArchiveApi* | [**archive_to_tape**](docs/TapeArchiveApi.md#archive_to_tape) | **POST** `/api/2/archive/tape/archive` | 
+*TapeArchiveApi* | [**cancel_all_tape_archive_jobs**](docs/TapeArchiveApi.md#cancel_all_tape_archive_jobs) | **POST** `/api/2/archive/tape/jobs/cancel-all` | 
+*TapeArchiveApi* | [**check_tape**](docs/TapeArchiveApi.md#check_tape) | **POST** `/api/2/archive/tape/library/check` | 
+*TapeArchiveApi* | [**create_tape**](docs/TapeArchiveApi.md#create_tape) | **POST** `/api/2/archive/tape/tapes` | 
+*TapeArchiveApi* | [**create_tape_group**](docs/TapeArchiveApi.md#create_tape_group) | **POST** `/api/2/archive/tape/groups` | 
+*TapeArchiveApi* | [**delete_tape**](docs/TapeArchiveApi.md#delete_tape) | **DELETE** `/api/2/archive/tape/tapes/{id}` | 
+*TapeArchiveApi* | [**delete_tape_archive_job**](docs/TapeArchiveApi.md#delete_tape_archive_job) | **DELETE** `/api/2/archive/tape/jobs/{id}` | 
+*TapeArchiveApi* | [**delete_tape_group**](docs/TapeArchiveApi.md#delete_tape_group) | **DELETE** `/api/2/archive/tape/groups/{id}` | 
+*TapeArchiveApi* | [**format_tape**](docs/TapeArchiveApi.md#format_tape) | **POST** `/api/2/archive/tape/library/format` | 
+*TapeArchiveApi* | [**get_all_archived_file_entries**](docs/TapeArchiveApi.md#get_all_archived_file_entries) | **GET** `/api/2/archive/tape/files` | 
+*TapeArchiveApi* | [**get_all_tape_archive_jobs**](docs/TapeArchiveApi.md#get_all_tape_archive_jobs) | **GET** `/api/2/archive/tape/jobs` | 
+*TapeArchiveApi* | [**get_all_tape_groups**](docs/TapeArchiveApi.md#get_all_tape_groups) | **GET** `/api/2/archive/tape/groups` | 
+*TapeArchiveApi* | [**get_all_tapes**](docs/TapeArchiveApi.md#get_all_tapes) | **GET** `/api/2/archive/tape/tapes` | 
+*TapeArchiveApi* | [**get_archived_file_entry**](docs/TapeArchiveApi.md#get_archived_file_entry) | **GET** `/api/2/archive/tape/files/{id}` | 
+*TapeArchiveApi* | [**get_tape**](docs/TapeArchiveApi.md#get_tape) | **GET** `/api/2/archive/tape/tapes/{id}` | 
+*TapeArchiveApi* | [**get_tape_archive_job**](docs/TapeArchiveApi.md#get_tape_archive_job) | **GET** `/api/2/archive/tape/jobs/{id}` | 
+*TapeArchiveApi* | [**get_tape_archive_job_sources**](docs/TapeArchiveApi.md#get_tape_archive_job_sources) | **GET** `/api/2/archive/tape/jobs/{id}/sources` | 
+*TapeArchiveApi* | [**get_tape_group**](docs/TapeArchiveApi.md#get_tape_group) | **GET** `/api/2/archive/tape/groups/{id}` | 
+*TapeArchiveApi* | [**get_tape_library_state**](docs/TapeArchiveApi.md#get_tape_library_state) | **GET** `/api/2/archive/tape/library` | 
+*TapeArchiveApi* | [**load_tape**](docs/TapeArchiveApi.md#load_tape) | **POST** `/api/2/archive/tape/library/load` | 
+*TapeArchiveApi* | [**move_tape**](docs/TapeArchiveApi.md#move_tape) | **POST** `/api/2/archive/tape/library/move` | 
+*TapeArchiveApi* | [**patch_tape**](docs/TapeArchiveApi.md#patch_tape) | **PATCH** `/api/2/archive/tape/tapes/{id}` | 
+*TapeArchiveApi* | [**patch_tape_group**](docs/TapeArchiveApi.md#patch_tape_group) | **PATCH** `/api/2/archive/tape/groups/{id}` | 
+*TapeArchiveApi* | [**pause_tape_archive_job**](docs/TapeArchiveApi.md#pause_tape_archive_job) | **POST** `/api/2/archive/tape/jobs/{id}/pause` | 
+*TapeArchiveApi* | [**refresh_tape_library_state**](docs/TapeArchiveApi.md#refresh_tape_library_state) | **POST** `/api/2/archive/tape/library/refresh` | 
+*TapeArchiveApi* | [**reindex_tape**](docs/TapeArchiveApi.md#reindex_tape) | **POST** `/api/2/archive/tape/library/reindex` | 
+*TapeArchiveApi* | [**remove_finished_tape_archive_jobs**](docs/TapeArchiveApi.md#remove_finished_tape_archive_jobs) | **POST** `/api/2/archive/tape/jobs/remove-finished` | 
+*TapeArchiveApi* | [**restart_tape_archive_job**](docs/TapeArchiveApi.md#restart_tape_archive_job) | **POST** `/api/2/archive/tape/jobs/{id}/restart` | 
+*TapeArchiveApi* | [**restore_from_tape**](docs/TapeArchiveApi.md#restore_from_tape) | **POST** `/api/2/archive/tape/restore` | 
+*TapeArchiveApi* | [**resume_tape_archive_job**](docs/TapeArchiveApi.md#resume_tape_archive_job) | **POST** `/api/2/archive/tape/jobs/{id}/resume` | 
+*TapeArchiveApi* | [**search_tape_archive**](docs/TapeArchiveApi.md#search_tape_archive) | **POST** `/api/2/archive/tape/search` | 
+*TapeArchiveApi* | [**unload_tape**](docs/TapeArchiveApi.md#unload_tape) | **POST** `/api/2/archive/tape/library/unload` | 
+*TapeArchiveApi* | [**update_tape**](docs/TapeArchiveApi.md#update_tape) | **PUT** `/api/2/archive/tape/tapes/{id}` | 
+*TapeArchiveApi* | [**update_tape_group**](docs/TapeArchiveApi.md#update_tape_group) | **PUT** `/api/2/archive/tape/groups/{id}` | 
 
 
 ## Models
 
- - [AIAnnotation](docs/AIAnnotation)
- - [AIAnnotationCreateRequest](docs/AIAnnotationCreateRequest)
- - [AIAnnotationPartialUpdate](docs/AIAnnotationPartialUpdate)
- - [AIAnnotationUpdate](docs/AIAnnotationUpdate)
- - [AICategory](docs/AICategory)
- - [AICategoryDetail](docs/AICategoryDetail)
- - [AICategoryDetailPartialUpdate](docs/AICategoryDetailPartialUpdate)
- - [AICategoryDetailUpdate](docs/AICategoryDetailUpdate)
- - [AICategoryMiniReference](docs/AICategoryMiniReference)
- - [AIConnection](docs/AIConnection)
- - [AIDataset](docs/AIDataset)
- - [AIDatasetDetailReference](docs/AIDatasetDetailReference)
- - [AIDatasetExportRequest](docs/AIDatasetExportRequest)
- - [AIDatasetExportResponse](docs/AIDatasetExportResponse)
- - [AIDatasetReference](docs/AIDatasetReference)
- - [AIDatasetWithPreview](docs/AIDatasetWithPreview)
- - [AIDatasetWithPreviewPartialUpdate](docs/AIDatasetWithPreviewPartialUpdate)
- - [AIDatasetWithPreviewUpdate](docs/AIDatasetWithPreviewUpdate)
- - [AIImage](docs/AIImage)
- - [AIImageReference](docs/AIImageReference)
- - [AIMetadata](docs/AIMetadata)
- - [AIModel](docs/AIModel)
- - [AIModelExportRequest](docs/AIModelExportRequest)
- - [AIModelExportResponse](docs/AIModelExportResponse)
- - [AIModelInferenceRequest](docs/AIModelInferenceRequest)
- - [AIModelInferenceResponse](docs/AIModelInferenceResponse)
- - [AIModelPartialUpdate](docs/AIModelPartialUpdate)
- - [AIModelProgress](docs/AIModelProgress)
- - [AIModelTrainingRequest](docs/AIModelTrainingRequest)
- - [AIModelUpdate](docs/AIModelUpdate)
- - [AIProcessingRequest](docs/AIProcessingRequest)
- - [APIToken](docs/APIToken)
- - [APITokenPartialUpdate](docs/APITokenPartialUpdate)
- - [APITokenUpdate](docs/APITokenUpdate)
- - [APITokenWithSecret](docs/APITokenWithSecret)
- - [APITokenWithSecretUpdate](docs/APITokenWithSecretUpdate)
- - [AddAssetsToClickGallery](docs/AddAssetsToClickGallery)
- - [Address](docs/Address)
- - [Alert](docs/Alert)
- - [AlertPartialUpdate](docs/AlertPartialUpdate)
- - [AlertUpdate](docs/AlertUpdate)
- - [AllMediaFilesForBundlesRequest](docs/AllMediaFilesForBundlesRequest)
- - [ArchiveEndpointRequest](docs/ArchiveEndpointRequest)
- - [ArgumentType](docs/ArgumentType)
- - [Asset](docs/Asset)
- - [AssetBackup](docs/AssetBackup)
- - [AssetCloudLink](docs/AssetCloudLink)
- - [AssetMini](docs/AssetMini)
- - [AssetMiniReference](docs/AssetMiniReference)
- - [AssetPartialUpdate](docs/AssetPartialUpdate)
- - [AssetProjectLink](docs/AssetProjectLink)
- - [AssetRating](docs/AssetRating)
- - [AssetRatingPartialUpdate](docs/AssetRatingPartialUpdate)
- - [AssetRatingUpdate](docs/AssetRatingUpdate)
- - [AssetSubtitleLink](docs/AssetSubtitleLink)
- - [AssetSubtitleLinkPartialUpdate](docs/AssetSubtitleLinkPartialUpdate)
- - [AssetSubtitleLinkUpdate](docs/AssetSubtitleLinkUpdate)
- - [AssetUpdate](docs/AssetUpdate)
- - [AuthLoginEndpointRequest](docs/AuthLoginEndpointRequest)
- - [AuthLoginEndpointResponse](docs/AuthLoginEndpointResponse)
- - [Backend](docs/Backend)
- - [BackendProperties](docs/BackendProperties)
- - [BasicFile](docs/BasicFile)
- - [BeeGFSNode](docs/BeeGFSNode)
- - [BeeGFSTarget](docs/BeeGFSTarget)
- - [BootstrapData](docs/BootstrapData)
- - [CPUStat](docs/CPUStat)
- - [Certificate](docs/Certificate)
- - [CertificateUpdate](docs/CertificateUpdate)
- - [ChangeOwnPasswordRequest](docs/ChangeOwnPasswordRequest)
- - [ChangePasswordRequest](docs/ChangePasswordRequest)
- - [CheckConnectivityEndpointResponse](docs/CheckConnectivityEndpointResponse)
- - [ClickBackgroundUploadEndpointRequest](docs/ClickBackgroundUploadEndpointRequest)
- - [ClickGallery](docs/ClickGallery)
- - [ClickGalleryLink](docs/ClickGalleryLink)
- - [ClickGalleryUpdate](docs/ClickGalleryUpdate)
- - [ClickLinkUser](docs/ClickLinkUser)
- - [ClickStartUploadEndpointRequest](docs/ClickStartUploadEndpointRequest)
- - [ClientSession](docs/ClientSession)
- - [ClientSidePathEndpointRequest](docs/ClientSidePathEndpointRequest)
- - [ClientSidePathEndpointResponse](docs/ClientSidePathEndpointResponse)
- - [ClientsEndpointResponse](docs/ClientsEndpointResponse)
- - [CloudAccount](docs/CloudAccount)
- - [CloudAccountMini](docs/CloudAccountMini)
- - [CloudAccountMiniPartialUpdate](docs/CloudAccountMiniPartialUpdate)
- - [CloudAccountMiniUpdate](docs/CloudAccountMiniUpdate)
- - [CloudAccountPartialUpdate](docs/CloudAccountPartialUpdate)
- - [CloudAccountUpdate](docs/CloudAccountUpdate)
- - [CloudConnection](docs/CloudConnection)
- - [Comment](docs/Comment)
- - [CommentPartialUpdate](docs/CommentPartialUpdate)
- - [CommentUpdate](docs/CommentUpdate)
- - [CreateDownloadArchive](docs/CreateDownloadArchive)
- - [CreateHomeWorkspaceRequest](docs/CreateHomeWorkspaceRequest)
- - [CreatePathQuotaRequest](docs/CreatePathQuotaRequest)
- - [CreateTemplateFolderEndpointRequest](docs/CreateTemplateFolderEndpointRequest)
- - [CustomField](docs/CustomField)
- - [CustomFieldPartialUpdate](docs/CustomFieldPartialUpdate)
- - [CustomFieldReference](docs/CustomFieldReference)
- - [CustomFieldUpdate](docs/CustomFieldUpdate)
- - [DeletedWorkspace](docs/DeletedWorkspace)
- - [Download](docs/Download)
- - [DownloadArchive](docs/DownloadArchive)
- - [DownloadArchivePartialUpdate](docs/DownloadArchivePartialUpdate)
- - [DownloadArchiveUpdate](docs/DownloadArchiveUpdate)
- - [EditorProject](docs/EditorProject)
- - [EditorProjectPartialUpdate](docs/EditorProjectPartialUpdate)
- - [EditorProjectUpdate](docs/EditorProjectUpdate)
- - [EditorSubtitle](docs/EditorSubtitle)
- - [EditorSubtitlePartialUpdate](docs/EditorSubtitlePartialUpdate)
- - [EditorSubtitleUpdate](docs/EditorSubtitleUpdate)
- - [ElementsGroup](docs/ElementsGroup)
- - [ElementsGroupDetail](docs/ElementsGroupDetail)
- - [ElementsGroupDetailPartialUpdate](docs/ElementsGroupDetailPartialUpdate)
- - [ElementsGroupDetailUpdate](docs/ElementsGroupDetailUpdate)
- - [ElementsGroupReference](docs/ElementsGroupReference)
- - [ElementsUser](docs/ElementsUser)
- - [ElementsUserDetail](docs/ElementsUserDetail)
- - [ElementsUserDetailPartialUpdate](docs/ElementsUserDetailPartialUpdate)
- - [ElementsUserDetailUpdate](docs/ElementsUserDetailUpdate)
- - [ElementsUserMini](docs/ElementsUserMini)
- - [ElementsUserMiniReference](docs/ElementsUserMiniReference)
- - [ElementsUserProfile](docs/ElementsUserProfile)
- - [ElementsUserProfilePartialUpdate](docs/ElementsUserProfilePartialUpdate)
- - [ElementsUserProfileUpdate](docs/ElementsUserProfileUpdate)
- - [ElementsUserReference](docs/ElementsUserReference)
- - [ElementsVersion](docs/ElementsVersion)
- - [EmailPreview](docs/EmailPreview)
- - [EnableTOTPRequest](docs/EnableTOTPRequest)
- - [Event](docs/Event)
- - [ExternalTranscoder](docs/ExternalTranscoder)
- - [ExternalTranscoderPartialUpdate](docs/ExternalTranscoderPartialUpdate)
- - [ExternalTranscoderUpdate](docs/ExternalTranscoderUpdate)
- - [ExtractRequest](docs/ExtractRequest)
- - [FSProperties](docs/FSProperties)
- - [FileCopyEndpointRequest](docs/FileCopyEndpointRequest)
- - [FileDeleteEndpointRequest](docs/FileDeleteEndpointRequest)
- - [FileMoveEndpointRequest](docs/FileMoveEndpointRequest)
- - [FilePartialUpdate](docs/FilePartialUpdate)
- - [FileSizeDistribution](docs/FileSizeDistribution)
- - [FileSizeDistributionItem](docs/FileSizeDistributionItem)
- - [FileSizeEndpointResponse](docs/FileSizeEndpointResponse)
- - [FileUnzipEndpointRequest](docs/FileUnzipEndpointRequest)
- - [FileUpdate](docs/FileUpdate)
- - [FileZipEndpointRequest](docs/FileZipEndpointRequest)
- - [FilesystemFile](docs/FilesystemFile)
- - [FilesystemPermission](docs/FilesystemPermission)
- - [FilesystemPermissionPartialUpdate](docs/FilesystemPermissionPartialUpdate)
- - [FilesystemPermissionUpdate](docs/FilesystemPermissionUpdate)
- - [FilesystemTraceEndpointRequest](docs/FilesystemTraceEndpointRequest)
- - [FilesystemTraceEndpointResponse](docs/FilesystemTraceEndpointResponse)
- - [FinishUploadEndpointRequest](docs/FinishUploadEndpointRequest)
- - [FormatMetadata](docs/FormatMetadata)
- - [GeneratePasswordEndpointResponse](docs/GeneratePasswordEndpointResponse)
- - [GenerateProxiesRequest](docs/GenerateProxiesRequest)
- - [GetMultipleBundlesRequest](docs/GetMultipleBundlesRequest)
- - [GetMultipleFilesRequest](docs/GetMultipleFilesRequest)
- - [GlobalAlert](docs/GlobalAlert)
- - [HelpEndpointResponse](docs/HelpEndpointResponse)
- - [IOStat](docs/IOStat)
- - [ImpersonationEndpointRequest](docs/ImpersonationEndpointRequest)
- - [ImportAIDatasetRequest](docs/ImportAIDatasetRequest)
- - [ImportAIDatasetResponse](docs/ImportAIDatasetResponse)
- - [ImportAIModelRequest](docs/ImportAIModelRequest)
- - [ImportAIModelResponse](docs/ImportAIModelResponse)
- - [ImportJobRequest](docs/ImportJobRequest)
- - [ImportJobResponse](docs/ImportJobResponse)
- - [InlineResponse200](docs/InlineResponse200)
- - [InstallLicenseEndpointRequest](docs/InstallLicenseEndpointRequest)
- - [InstantiateFileTemplateRequest](docs/InstantiateFileTemplateRequest)
- - [Interface](docs/Interface)
- - [Ipmi](docs/Ipmi)
- - [Job](docs/Job)
- - [JobPartialUpdate](docs/JobPartialUpdate)
- - [JobReference](docs/JobReference)
- - [JobUpdate](docs/JobUpdate)
- - [KapacitorAlert](docs/KapacitorAlert)
- - [LDAPServer](docs/LDAPServer)
- - [LDAPServerGroup](docs/LDAPServerGroup)
- - [LDAPServerGroups](docs/LDAPServerGroups)
- - [LDAPServerReference](docs/LDAPServerReference)
- - [LDAPServerUser](docs/LDAPServerUser)
- - [LDAPServerUsers](docs/LDAPServerUsers)
- - [License](docs/License)
- - [ListTopics](docs/ListTopics)
- - [LizardFSDisk](docs/LizardFSDisk)
- - [LizardFSNode](docs/LizardFSNode)
- - [LocaleEndpointResponse](docs/LocaleEndpointResponse)
- - [LocateEndpointRequest](docs/LocateEndpointRequest)
- - [LocateProxiesEndpointRequest](docs/LocateProxiesEndpointRequest)
- - [LocateProxiesEndpointResponse](docs/LocateProxiesEndpointResponse)
- - [LocateResult](docs/LocateResult)
- - [Marker](docs/Marker)
- - [MarkerPartialUpdate](docs/MarkerPartialUpdate)
- - [MarkerUpdate](docs/MarkerUpdate)
- - [MediaFile](docs/MediaFile)
- - [MediaFileBundle](docs/MediaFileBundle)
- - [MediaFileBundleMini](docs/MediaFileBundleMini)
- - [MediaFileBundleMiniReference](docs/MediaFileBundleMiniReference)
- - [MediaFileContents](docs/MediaFileContents)
- - [MediaFileMini](docs/MediaFileMini)
- - [MediaFilePartialUpdate](docs/MediaFilePartialUpdate)
- - [MediaFileReference](docs/MediaFileReference)
- - [MediaFileTemplate](docs/MediaFileTemplate)
- - [MediaFileTemplatePartialUpdate](docs/MediaFileTemplatePartialUpdate)
- - [MediaFileTemplateUpdate](docs/MediaFileTemplateUpdate)
- - [MediaFileUpdate](docs/MediaFileUpdate)
- - [MediaFilesLookupRequest](docs/MediaFilesLookupRequest)
- - [MediaLibraryDeleteRequest](docs/MediaLibraryDeleteRequest)
- - [MediaLibraryShareRequest](docs/MediaLibraryShareRequest)
- - [MediaRoot](docs/MediaRoot)
- - [MediaRootDetail](docs/MediaRootDetail)
- - [MediaRootDetailPartialUpdate](docs/MediaRootDetailPartialUpdate)
- - [MediaRootDetailUpdate](docs/MediaRootDetailUpdate)
- - [MediaRootMini](docs/MediaRootMini)
- - [MediaRootMiniReference](docs/MediaRootMiniReference)
- - [MediaRootPermission](docs/MediaRootPermission)
- - [MediaRootPermissionAccessOptions](docs/MediaRootPermissionAccessOptions)
- - [MediaRootPermissionPartialUpdate](docs/MediaRootPermissionPartialUpdate)
- - [MediaRootPermissionUpdate](docs/MediaRootPermissionUpdate)
- - [MediaUpdate](docs/MediaUpdate)
- - [MemberPreview](docs/MemberPreview)
- - [MetadataItem](docs/MetadataItem)
- - [MoveWorkspaceRequest](docs/MoveWorkspaceRequest)
- - [MultipleAssetsRequest](docs/MultipleAssetsRequest)
- - [NFSPermission](docs/NFSPermission)
- - [NTPServer](docs/NTPServer)
- - [NTPServerPartialUpdate](docs/NTPServerPartialUpdate)
- - [NTPServerUpdate](docs/NTPServerUpdate)
- - [NetStat](docs/NetStat)
- - [OneTimeAccessToken](docs/OneTimeAccessToken)
- - [OneTimeAccessTokenActivity](docs/OneTimeAccessTokenActivity)
- - [OneTimeAccessTokenSharedObject](docs/OneTimeAccessTokenSharedObject)
- - [Parameters](docs/Parameters)
- - [ParametersUpdate](docs/ParametersUpdate)
- - [ParseSAMLIDPMetadataRequest](docs/ParseSAMLIDPMetadataRequest)
- - [ParsedSAMLIDPMetadata](docs/ParsedSAMLIDPMetadata)
- - [PasswordResetEndpointRequest](docs/PasswordResetEndpointRequest)
- - [Path](docs/Path)
- - [PathInput](docs/PathInput)
- - [Production](docs/Production)
- - [ProductionMiniReference](docs/ProductionMiniReference)
- - [ProductionPartialUpdate](docs/ProductionPartialUpdate)
- - [ProductionReference](docs/ProductionReference)
- - [ProductionUpdate](docs/ProductionUpdate)
- - [Proxy](docs/Proxy)
- - [ProxyCount](docs/ProxyCount)
- - [ProxyFSSizeEndpointResponse](docs/ProxyFSSizeEndpointResponse)
- - [ProxyGenerator](docs/ProxyGenerator)
- - [ProxyGeneratorProperties](docs/ProxyGeneratorProperties)
- - [ProxyProfile](docs/ProxyProfile)
- - [ProxyProfileMini](docs/ProxyProfileMini)
- - [ProxyProfilePartialUpdate](docs/ProxyProfilePartialUpdate)
- - [ProxyProfileUpdate](docs/ProxyProfileUpdate)
- - [PythonEnvironment](docs/PythonEnvironment)
- - [Queue](docs/Queue)
- - [Quota](docs/Quota)
- - [RAMStat](docs/RAMStat)
- - [RDCActivation](docs/RDCActivation)
- - [RDCHost](docs/RDCHost)
- - [RDCSession](docs/RDCSession)
- - [RDCSessionCreate](docs/RDCSessionCreate)
- - [RegisterUploadEndpointRequest](docs/RegisterUploadEndpointRequest)
- - [RegisterUploadMetadataEndpointRequest](docs/RegisterUploadMetadataEndpointRequest)
- - [ReleaseNotesEndpointResponse](docs/ReleaseNotesEndpointResponse)
- - [RenameCustomFieldRequest](docs/RenameCustomFieldRequest)
- - [RenderEndpointRequest](docs/RenderEndpointRequest)
- - [RenderRequest](docs/RenderRequest)
- - [RestoreEndpointRequest](docs/RestoreEndpointRequest)
- - [SAMLProvider](docs/SAMLProvider)
- - [SAMLProviderMini](docs/SAMLProviderMini)
- - [SAMLProviderPartialUpdate](docs/SAMLProviderPartialUpdate)
- - [SAMLProviderUpdate](docs/SAMLProviderUpdate)
- - [SMTPConfiguration](docs/SMTPConfiguration)
- - [SMTPConfigurationUpdate](docs/SMTPConfigurationUpdate)
- - [SNFSStripeGroup](docs/SNFSStripeGroup)
- - [SavedSearch](docs/SavedSearch)
- - [SavedSearchPartialUpdate](docs/SavedSearchPartialUpdate)
- - [SavedSearchUpdate](docs/SavedSearchUpdate)
- - [ScannerDiscoverEndpointRequest](docs/ScannerDiscoverEndpointRequest)
- - [ScannerScanEndpointRequest](docs/ScannerScanEndpointRequest)
- - [Schedule](docs/Schedule)
- - [SchedulePartialUpdate](docs/SchedulePartialUpdate)
- - [ScheduleReference](docs/ScheduleReference)
- - [ScheduleUpdate](docs/ScheduleUpdate)
- - [SearchEndpointRequest](docs/SearchEndpointRequest)
- - [SearchEndpointResponse](docs/SearchEndpointResponse)
- - [SendLinkEmailRequest](docs/SendLinkEmailRequest)
- - [Sensor](docs/Sensor)
- - [Sensors](docs/Sensors)
- - [ServiceStatus](docs/ServiceStatus)
- - [Share](docs/Share)
- - [SharePartialUpdate](docs/SharePartialUpdate)
- - [ShareToHomeWorkspaceEndpointRequest](docs/ShareToHomeWorkspaceEndpointRequest)
- - [ShareUpdate](docs/ShareUpdate)
- - [SlackChannel](docs/SlackChannel)
- - [SlackConnection](docs/SlackConnection)
- - [SlackConnectionPartialUpdate](docs/SlackConnectionPartialUpdate)
- - [SlackConnectionStatus](docs/SlackConnectionStatus)
- - [SlackConnectionUpdate](docs/SlackConnectionUpdate)
- - [SlackEmoji](docs/SlackEmoji)
- - [SlackMessage](docs/SlackMessage)
- - [SlackUser](docs/SlackUser)
- - [Snapshot](docs/Snapshot)
- - [SnapshotPartialUpdate](docs/SnapshotPartialUpdate)
- - [SnapshotUpdate](docs/SnapshotUpdate)
- - [SolrReindexEndpointResponse](docs/SolrReindexEndpointResponse)
- - [StartJobRequest](docs/StartJobRequest)
- - [StartTaskRequest](docs/StartTaskRequest)
- - [Stats](docs/Stats)
- - [StorNextConnection](docs/StorNextConnection)
- - [StorNextConnections](docs/StorNextConnections)
- - [StorNextLicenseCheckEndpointResponse](docs/StorNextLicenseCheckEndpointResponse)
- - [StorNextLicenseEndpointResponse](docs/StorNextLicenseEndpointResponse)
- - [StorageNode](docs/StorageNode)
- - [StorageNodeMini](docs/StorageNodeMini)
- - [StorageNodeStatus](docs/StorageNodeStatus)
- - [StorageRequest](docs/StorageRequest)
- - [StorageResponse](docs/StorageResponse)
- - [StorageRoot](docs/StorageRoot)
- - [StornextLicense](docs/StornextLicense)
- - [StornextManagerAttributes](docs/StornextManagerAttributes)
- - [Subclip](docs/Subclip)
- - [SubclipClipboardEntry](docs/SubclipClipboardEntry)
- - [SubclipClipboardEntryUpdate](docs/SubclipClipboardEntryUpdate)
- - [SubclipPartialUpdate](docs/SubclipPartialUpdate)
- - [SubclipReference](docs/SubclipReference)
- - [SubclipUpdate](docs/SubclipUpdate)
- - [Subscription](docs/Subscription)
- - [Subtask](docs/Subtask)
- - [SubtaskPartialUpdate](docs/SubtaskPartialUpdate)
- - [SubtaskReference](docs/SubtaskReference)
- - [SubtaskUpdate](docs/SubtaskUpdate)
- - [Subtitle](docs/Subtitle)
- - [SubtitleClipboardEntry](docs/SubtitleClipboardEntry)
- - [SubtitleClipboardEntryUpdate](docs/SubtitleClipboardEntryUpdate)
- - [SubtitleEvent](docs/SubtitleEvent)
- - [SyncTOTP](docs/SyncTOTP)
- - [SyncTOTPRequest](docs/SyncTOTPRequest)
- - [SystemInfoEndpointResponse](docs/SystemInfoEndpointResponse)
- - [TagMediaDirectoryRequest](docs/TagMediaDirectoryRequest)
- - [TagReference](docs/TagReference)
- - [Tape](docs/Tape)
- - [TapeFile](docs/TapeFile)
- - [TapeGroup](docs/TapeGroup)
- - [TapeGroupPartialUpdate](docs/TapeGroupPartialUpdate)
- - [TapeGroupUpdate](docs/TapeGroupUpdate)
- - [TapeJob](docs/TapeJob)
- - [TapeJobSource](docs/TapeJobSource)
- - [TapeLibraryEndpointResponse](docs/TapeLibraryEndpointResponse)
- - [TapeLibraryFormatEndpointRequest](docs/TapeLibraryFormatEndpointRequest)
- - [TapeLibraryFsckEndpointRequest](docs/TapeLibraryFsckEndpointRequest)
- - [TapeLibraryLoadEndpointRequest](docs/TapeLibraryLoadEndpointRequest)
- - [TapeLibraryMoveEndpointRequest](docs/TapeLibraryMoveEndpointRequest)
- - [TapeLibraryReindexEndpointRequest](docs/TapeLibraryReindexEndpointRequest)
- - [TapeLibrarySlot](docs/TapeLibrarySlot)
- - [TapeLibraryUnloadEndpointRequest](docs/TapeLibraryUnloadEndpointRequest)
- - [TapePartialUpdate](docs/TapePartialUpdate)
- - [TapeReference](docs/TapeReference)
- - [TapeUpdate](docs/TapeUpdate)
- - [TaskInfo](docs/TaskInfo)
- - [TaskLog](docs/TaskLog)
- - [TaskProgress](docs/TaskProgress)
- - [TaskType](docs/TaskType)
- - [TasksSummary](docs/TasksSummary)
- - [TeamsConnection](docs/TeamsConnection)
- - [TeamsConnectionPartialUpdate](docs/TeamsConnectionPartialUpdate)
- - [TeamsConnectionStatus](docs/TeamsConnectionStatus)
- - [TeamsConnectionUpdate](docs/TeamsConnectionUpdate)
- - [TeamsMessage](docs/TeamsMessage)
- - [TeamsRecipient](docs/TeamsRecipient)
- - [TestAWSCredentialsRequest](docs/TestAWSCredentialsRequest)
- - [TestAWSCredentialsResponse](docs/TestAWSCredentialsResponse)
- - [TestCloudAccountCredentialsRequest](docs/TestCloudAccountCredentialsRequest)
- - [TestCloudAccountCredentialsResponse](docs/TestCloudAccountCredentialsResponse)
- - [TestExternalTranscoderConnectionRequest](docs/TestExternalTranscoderConnectionRequest)
- - [TestExternalTranscoderConnectionResponse](docs/TestExternalTranscoderConnectionResponse)
- - [TestSMTP](docs/TestSMTP)
- - [Ticket](docs/Ticket)
- - [TimeEndpointRequest](docs/TimeEndpointRequest)
- - [TimeEndpointResponse](docs/TimeEndpointResponse)
- - [TimeSyncEndpointRequest](docs/TimeSyncEndpointRequest)
- - [TimeSyncEndpointResponse](docs/TimeSyncEndpointResponse)
- - [TimelineExportRequest](docs/TimelineExportRequest)
- - [Timezone](docs/Timezone)
- - [TraceNode](docs/TraceNode)
- - [TranscoderProfile](docs/TranscoderProfile)
- - [TypeDocumentation](docs/TypeDocumentation)
- - [UnfilteredTag](docs/UnfilteredTag)
- - [UnfilteredTagPartialUpdate](docs/UnfilteredTagPartialUpdate)
- - [UnfilteredTagUpdate](docs/UnfilteredTagUpdate)
- - [UpdateQuotaRequest](docs/UpdateQuotaRequest)
- - [UploadAIImageRequest](docs/UploadAIImageRequest)
- - [UploadChunkEndpointRequest](docs/UploadChunkEndpointRequest)
- - [UploadImageEndpointRequest](docs/UploadImageEndpointRequest)
- - [UserPreviewRequest](docs/UserPreviewRequest)
- - [UserPreviewResponse](docs/UserPreviewResponse)
- - [VantageWorkflow](docs/VantageWorkflow)
- - [VantageWorkflows](docs/VantageWorkflows)
- - [VeritoneConnection](docs/VeritoneConnection)
- - [VeritoneEngineList](docs/VeritoneEngineList)
- - [VeritoneJobList](docs/VeritoneJobList)
- - [VeritoneMetadata](docs/VeritoneMetadata)
- - [VeritoneUploadRequest](docs/VeritoneUploadRequest)
- - [Volume](docs/Volume)
- - [VolumeBeeGFSStatus](docs/VolumeBeeGFSStatus)
- - [VolumeLizardFSStatus](docs/VolumeLizardFSStatus)
- - [VolumeMini](docs/VolumeMini)
- - [VolumeMiniReference](docs/VolumeMiniReference)
- - [VolumePartialUpdate](docs/VolumePartialUpdate)
- - [VolumeReference](docs/VolumeReference)
- - [VolumeSNFSStatus](docs/VolumeSNFSStatus)
- - [VolumeStat](docs/VolumeStat)
- - [VolumeStats](docs/VolumeStats)
- - [VolumeStatus](docs/VolumeStatus)
- - [VolumeUpdate](docs/VolumeUpdate)
- - [WorkflowTransitionRequest](docs/WorkflowTransitionRequest)
- - [WorkflowTransitionResponse](docs/WorkflowTransitionResponse)
- - [Workspace](docs/Workspace)
- - [WorkspaceCheckIn](docs/WorkspaceCheckIn)
- - [WorkspaceDetail](docs/WorkspaceDetail)
- - [WorkspaceDetailPartialUpdate](docs/WorkspaceDetailPartialUpdate)
- - [WorkspaceDetailUpdate](docs/WorkspaceDetailUpdate)
- - [WorkspaceEndpoint](docs/WorkspaceEndpoint)
- - [WorkspaceMoveToRequest](docs/WorkspaceMoveToRequest)
- - [WorkspacePermission](docs/WorkspacePermission)
- - [WorkspacePermissionPartialUpdate](docs/WorkspacePermissionPartialUpdate)
- - [WorkspacePermissionUpdate](docs/WorkspacePermissionUpdate)
- - [WorkspaceResolvedPermission](docs/WorkspaceResolvedPermission)
- - [Workstation](docs/Workstation)
- - [WorkstationMini](docs/WorkstationMini)
- - [WorkstationPartialUpdate](docs/WorkstationPartialUpdate)
- - [WorkstationUpdate](docs/WorkstationUpdate)
+ - [AIAnnotation](docs/AIAnnotation.md)
+ - [AIAnnotationCreateRequest](docs/AIAnnotationCreateRequest.md)
+ - [AIAnnotationPartialUpdate](docs/AIAnnotationPartialUpdate.md)
+ - [AIAnnotationUpdate](docs/AIAnnotationUpdate.md)
+ - [AICategory](docs/AICategory.md)
+ - [AICategoryDetail](docs/AICategoryDetail.md)
+ - [AICategoryDetailPartialUpdate](docs/AICategoryDetailPartialUpdate.md)
+ - [AICategoryDetailUpdate](docs/AICategoryDetailUpdate.md)
+ - [AICategoryMiniReference](docs/AICategoryMiniReference.md)
+ - [AIConnection](docs/AIConnection.md)
+ - [AIDataset](docs/AIDataset.md)
+ - [AIDatasetDetailReference](docs/AIDatasetDetailReference.md)
+ - [AIDatasetExportRequest](docs/AIDatasetExportRequest.md)
+ - [AIDatasetExportResponse](docs/AIDatasetExportResponse.md)
+ - [AIDatasetReference](docs/AIDatasetReference.md)
+ - [AIDatasetWithPreview](docs/AIDatasetWithPreview.md)
+ - [AIDatasetWithPreviewPartialUpdate](docs/AIDatasetWithPreviewPartialUpdate.md)
+ - [AIDatasetWithPreviewUpdate](docs/AIDatasetWithPreviewUpdate.md)
+ - [AIImage](docs/AIImage.md)
+ - [AIImageReference](docs/AIImageReference.md)
+ - [AIMetadata](docs/AIMetadata.md)
+ - [AIModel](docs/AIModel.md)
+ - [AIModelExportRequest](docs/AIModelExportRequest.md)
+ - [AIModelExportResponse](docs/AIModelExportResponse.md)
+ - [AIModelInferenceRequest](docs/AIModelInferenceRequest.md)
+ - [AIModelInferenceResponse](docs/AIModelInferenceResponse.md)
+ - [AIModelPartialUpdate](docs/AIModelPartialUpdate.md)
+ - [AIModelProgress](docs/AIModelProgress.md)
+ - [AIModelTrainingRequest](docs/AIModelTrainingRequest.md)
+ - [AIModelUpdate](docs/AIModelUpdate.md)
+ - [AIProcessingRequest](docs/AIProcessingRequest.md)
+ - [APIToken](docs/APIToken.md)
+ - [APITokenPartialUpdate](docs/APITokenPartialUpdate.md)
+ - [APITokenUpdate](docs/APITokenUpdate.md)
+ - [APITokenWithSecret](docs/APITokenWithSecret.md)
+ - [APITokenWithSecretUpdate](docs/APITokenWithSecretUpdate.md)
+ - [AddAssetsToClickGallery](docs/AddAssetsToClickGallery.md)
+ - [Address](docs/Address.md)
+ - [Alert](docs/Alert.md)
+ - [AlertPartialUpdate](docs/AlertPartialUpdate.md)
+ - [AlertUpdate](docs/AlertUpdate.md)
+ - [AllMediaFilesForBundlesRequest](docs/AllMediaFilesForBundlesRequest.md)
+ - [ArchiveEndpointRequest](docs/ArchiveEndpointRequest.md)
+ - [ArgumentType](docs/ArgumentType.md)
+ - [Asset](docs/Asset.md)
+ - [AssetBackup](docs/AssetBackup.md)
+ - [AssetCloudLink](docs/AssetCloudLink.md)
+ - [AssetMini](docs/AssetMini.md)
+ - [AssetMiniReference](docs/AssetMiniReference.md)
+ - [AssetPartialUpdate](docs/AssetPartialUpdate.md)
+ - [AssetProjectLink](docs/AssetProjectLink.md)
+ - [AssetRating](docs/AssetRating.md)
+ - [AssetRatingPartialUpdate](docs/AssetRatingPartialUpdate.md)
+ - [AssetRatingUpdate](docs/AssetRatingUpdate.md)
+ - [AssetSubtitleLink](docs/AssetSubtitleLink.md)
+ - [AssetSubtitleLinkPartialUpdate](docs/AssetSubtitleLinkPartialUpdate.md)
+ - [AssetSubtitleLinkUpdate](docs/AssetSubtitleLinkUpdate.md)
+ - [AssetUpdate](docs/AssetUpdate.md)
+ - [AuthLoginEndpointRequest](docs/AuthLoginEndpointRequest.md)
+ - [AuthLoginEndpointResponse](docs/AuthLoginEndpointResponse.md)
+ - [Backend](docs/Backend.md)
+ - [BackendProperties](docs/BackendProperties.md)
+ - [BasicFile](docs/BasicFile.md)
+ - [BeeGFSNode](docs/BeeGFSNode.md)
+ - [BeeGFSTarget](docs/BeeGFSTarget.md)
+ - [BootstrapData](docs/BootstrapData.md)
+ - [CPUStat](docs/CPUStat.md)
+ - [Certificate](docs/Certificate.md)
+ - [CertificateUpdate](docs/CertificateUpdate.md)
+ - [ChangeOwnPasswordRequest](docs/ChangeOwnPasswordRequest.md)
+ - [ChangePasswordRequest](docs/ChangePasswordRequest.md)
+ - [CheckConnectivityEndpointResponse](docs/CheckConnectivityEndpointResponse.md)
+ - [ClickBackgroundUploadEndpointRequest](docs/ClickBackgroundUploadEndpointRequest.md)
+ - [ClickGallery](docs/ClickGallery.md)
+ - [ClickGalleryLink](docs/ClickGalleryLink.md)
+ - [ClickGalleryUpdate](docs/ClickGalleryUpdate.md)
+ - [ClickLinkUser](docs/ClickLinkUser.md)
+ - [ClickStartUploadEndpointRequest](docs/ClickStartUploadEndpointRequest.md)
+ - [ClientSession](docs/ClientSession.md)
+ - [ClientSidePathEndpointRequest](docs/ClientSidePathEndpointRequest.md)
+ - [ClientSidePathEndpointResponse](docs/ClientSidePathEndpointResponse.md)
+ - [ClientsEndpointResponse](docs/ClientsEndpointResponse.md)
+ - [CloudAccount](docs/CloudAccount.md)
+ - [CloudAccountMini](docs/CloudAccountMini.md)
+ - [CloudAccountMiniPartialUpdate](docs/CloudAccountMiniPartialUpdate.md)
+ - [CloudAccountMiniUpdate](docs/CloudAccountMiniUpdate.md)
+ - [CloudAccountPartialUpdate](docs/CloudAccountPartialUpdate.md)
+ - [CloudAccountUpdate](docs/CloudAccountUpdate.md)
+ - [CloudConnection](docs/CloudConnection.md)
+ - [Comment](docs/Comment.md)
+ - [CommentPartialUpdate](docs/CommentPartialUpdate.md)
+ - [CommentUpdate](docs/CommentUpdate.md)
+ - [CreateDownloadArchive](docs/CreateDownloadArchive.md)
+ - [CreateHomeWorkspaceRequest](docs/CreateHomeWorkspaceRequest.md)
+ - [CreatePathQuotaRequest](docs/CreatePathQuotaRequest.md)
+ - [CreateTemplateFolderEndpointRequest](docs/CreateTemplateFolderEndpointRequest.md)
+ - [CustomField](docs/CustomField.md)
+ - [CustomFieldPartialUpdate](docs/CustomFieldPartialUpdate.md)
+ - [CustomFieldReference](docs/CustomFieldReference.md)
+ - [CustomFieldUpdate](docs/CustomFieldUpdate.md)
+ - [DeletedWorkspace](docs/DeletedWorkspace.md)
+ - [Download](docs/Download.md)
+ - [DownloadArchive](docs/DownloadArchive.md)
+ - [DownloadArchivePartialUpdate](docs/DownloadArchivePartialUpdate.md)
+ - [DownloadArchiveUpdate](docs/DownloadArchiveUpdate.md)
+ - [EditorProject](docs/EditorProject.md)
+ - [EditorProjectPartialUpdate](docs/EditorProjectPartialUpdate.md)
+ - [EditorProjectUpdate](docs/EditorProjectUpdate.md)
+ - [EditorSubtitle](docs/EditorSubtitle.md)
+ - [EditorSubtitlePartialUpdate](docs/EditorSubtitlePartialUpdate.md)
+ - [EditorSubtitleUpdate](docs/EditorSubtitleUpdate.md)
+ - [ElementsGroup](docs/ElementsGroup.md)
+ - [ElementsGroupDetail](docs/ElementsGroupDetail.md)
+ - [ElementsGroupDetailPartialUpdate](docs/ElementsGroupDetailPartialUpdate.md)
+ - [ElementsGroupDetailUpdate](docs/ElementsGroupDetailUpdate.md)
+ - [ElementsGroupReference](docs/ElementsGroupReference.md)
+ - [ElementsUser](docs/ElementsUser.md)
+ - [ElementsUserDetail](docs/ElementsUserDetail.md)
+ - [ElementsUserDetailPartialUpdate](docs/ElementsUserDetailPartialUpdate.md)
+ - [ElementsUserDetailUpdate](docs/ElementsUserDetailUpdate.md)
+ - [ElementsUserMini](docs/ElementsUserMini.md)
+ - [ElementsUserMiniReference](docs/ElementsUserMiniReference.md)
+ - [ElementsUserProfile](docs/ElementsUserProfile.md)
+ - [ElementsUserProfilePartialUpdate](docs/ElementsUserProfilePartialUpdate.md)
+ - [ElementsUserProfileUpdate](docs/ElementsUserProfileUpdate.md)
+ - [ElementsUserReference](docs/ElementsUserReference.md)
+ - [ElementsVersion](docs/ElementsVersion.md)
+ - [EmailPreview](docs/EmailPreview.md)
+ - [EnableTOTPRequest](docs/EnableTOTPRequest.md)
+ - [Event](docs/Event.md)
+ - [ExternalTranscoder](docs/ExternalTranscoder.md)
+ - [ExternalTranscoderPartialUpdate](docs/ExternalTranscoderPartialUpdate.md)
+ - [ExternalTranscoderUpdate](docs/ExternalTranscoderUpdate.md)
+ - [ExtractRequest](docs/ExtractRequest.md)
+ - [FSProperties](docs/FSProperties.md)
+ - [FileCopyEndpointRequest](docs/FileCopyEndpointRequest.md)
+ - [FileDeleteEndpointRequest](docs/FileDeleteEndpointRequest.md)
+ - [FileMoveEndpointRequest](docs/FileMoveEndpointRequest.md)
+ - [FilePartialUpdate](docs/FilePartialUpdate.md)
+ - [FileSizeDistribution](docs/FileSizeDistribution.md)
+ - [FileSizeDistributionItem](docs/FileSizeDistributionItem.md)
+ - [FileSizeEndpointResponse](docs/FileSizeEndpointResponse.md)
+ - [FileUnzipEndpointRequest](docs/FileUnzipEndpointRequest.md)
+ - [FileUpdate](docs/FileUpdate.md)
+ - [FileZipEndpointRequest](docs/FileZipEndpointRequest.md)
+ - [FilesystemFile](docs/FilesystemFile.md)
+ - [FilesystemPermission](docs/FilesystemPermission.md)
+ - [FilesystemPermissionPartialUpdate](docs/FilesystemPermissionPartialUpdate.md)
+ - [FilesystemPermissionUpdate](docs/FilesystemPermissionUpdate.md)
+ - [FilesystemTraceEndpointRequest](docs/FilesystemTraceEndpointRequest.md)
+ - [FilesystemTraceEndpointResponse](docs/FilesystemTraceEndpointResponse.md)
+ - [FinishUploadEndpointRequest](docs/FinishUploadEndpointRequest.md)
+ - [FormatMetadata](docs/FormatMetadata.md)
+ - [GeneratePasswordEndpointResponse](docs/GeneratePasswordEndpointResponse.md)
+ - [GenerateProxiesRequest](docs/GenerateProxiesRequest.md)
+ - [GetMultipleBundlesRequest](docs/GetMultipleBundlesRequest.md)
+ - [GetMultipleFilesRequest](docs/GetMultipleFilesRequest.md)
+ - [GlobalAlert](docs/GlobalAlert.md)
+ - [HelpEndpointResponse](docs/HelpEndpointResponse.md)
+ - [IOStat](docs/IOStat.md)
+ - [ImpersonationEndpointRequest](docs/ImpersonationEndpointRequest.md)
+ - [ImportAIDatasetRequest](docs/ImportAIDatasetRequest.md)
+ - [ImportAIDatasetResponse](docs/ImportAIDatasetResponse.md)
+ - [ImportAIModelRequest](docs/ImportAIModelRequest.md)
+ - [ImportAIModelResponse](docs/ImportAIModelResponse.md)
+ - [ImportJobRequest](docs/ImportJobRequest.md)
+ - [ImportJobResponse](docs/ImportJobResponse.md)
+ - [InlineResponse200](docs/InlineResponse200.md)
+ - [InstallLicenseEndpointRequest](docs/InstallLicenseEndpointRequest.md)
+ - [InstantiateFileTemplateRequest](docs/InstantiateFileTemplateRequest.md)
+ - [Interface](docs/Interface.md)
+ - [Ipmi](docs/Ipmi.md)
+ - [Job](docs/Job.md)
+ - [JobPartialUpdate](docs/JobPartialUpdate.md)
+ - [JobReference](docs/JobReference.md)
+ - [JobUpdate](docs/JobUpdate.md)
+ - [KapacitorAlert](docs/KapacitorAlert.md)
+ - [LDAPServer](docs/LDAPServer.md)
+ - [LDAPServerGroup](docs/LDAPServerGroup.md)
+ - [LDAPServerGroups](docs/LDAPServerGroups.md)
+ - [LDAPServerReference](docs/LDAPServerReference.md)
+ - [LDAPServerUser](docs/LDAPServerUser.md)
+ - [LDAPServerUsers](docs/LDAPServerUsers.md)
+ - [License](docs/License.md)
+ - [ListTopics](docs/ListTopics.md)
+ - [LizardFSDisk](docs/LizardFSDisk.md)
+ - [LizardFSNode](docs/LizardFSNode.md)
+ - [LocaleEndpointResponse](docs/LocaleEndpointResponse.md)
+ - [LocateEndpointRequest](docs/LocateEndpointRequest.md)
+ - [LocateProxiesEndpointRequest](docs/LocateProxiesEndpointRequest.md)
+ - [LocateProxiesEndpointResponse](docs/LocateProxiesEndpointResponse.md)
+ - [LocateResult](docs/LocateResult.md)
+ - [Marker](docs/Marker.md)
+ - [MarkerPartialUpdate](docs/MarkerPartialUpdate.md)
+ - [MarkerUpdate](docs/MarkerUpdate.md)
+ - [MediaFile](docs/MediaFile.md)
+ - [MediaFileBundle](docs/MediaFileBundle.md)
+ - [MediaFileBundleMini](docs/MediaFileBundleMini.md)
+ - [MediaFileBundleMiniReference](docs/MediaFileBundleMiniReference.md)
+ - [MediaFileContents](docs/MediaFileContents.md)
+ - [MediaFileMini](docs/MediaFileMini.md)
+ - [MediaFilePartialUpdate](docs/MediaFilePartialUpdate.md)
+ - [MediaFileReference](docs/MediaFileReference.md)
+ - [MediaFileTemplate](docs/MediaFileTemplate.md)
+ - [MediaFileTemplatePartialUpdate](docs/MediaFileTemplatePartialUpdate.md)
+ - [MediaFileTemplateUpdate](docs/MediaFileTemplateUpdate.md)
+ - [MediaFileUpdate](docs/MediaFileUpdate.md)
+ - [MediaFilesLookupRequest](docs/MediaFilesLookupRequest.md)
+ - [MediaLibraryDeleteRequest](docs/MediaLibraryDeleteRequest.md)
+ - [MediaLibraryShareRequest](docs/MediaLibraryShareRequest.md)
+ - [MediaRoot](docs/MediaRoot.md)
+ - [MediaRootDetail](docs/MediaRootDetail.md)
+ - [MediaRootDetailPartialUpdate](docs/MediaRootDetailPartialUpdate.md)
+ - [MediaRootDetailUpdate](docs/MediaRootDetailUpdate.md)
+ - [MediaRootMini](docs/MediaRootMini.md)
+ - [MediaRootMiniReference](docs/MediaRootMiniReference.md)
+ - [MediaRootPermission](docs/MediaRootPermission.md)
+ - [MediaRootPermissionAccessOptions](docs/MediaRootPermissionAccessOptions.md)
+ - [MediaRootPermissionPartialUpdate](docs/MediaRootPermissionPartialUpdate.md)
+ - [MediaRootPermissionUpdate](docs/MediaRootPermissionUpdate.md)
+ - [MediaUpdate](docs/MediaUpdate.md)
+ - [MemberPreview](docs/MemberPreview.md)
+ - [MetadataItem](docs/MetadataItem.md)
+ - [MoveWorkspaceRequest](docs/MoveWorkspaceRequest.md)
+ - [MultipleAssetsRequest](docs/MultipleAssetsRequest.md)
+ - [NFSPermission](docs/NFSPermission.md)
+ - [NTPServer](docs/NTPServer.md)
+ - [NTPServerPartialUpdate](docs/NTPServerPartialUpdate.md)
+ - [NTPServerUpdate](docs/NTPServerUpdate.md)
+ - [NetStat](docs/NetStat.md)
+ - [OneTimeAccessToken](docs/OneTimeAccessToken.md)
+ - [OneTimeAccessTokenActivity](docs/OneTimeAccessTokenActivity.md)
+ - [OneTimeAccessTokenSharedObject](docs/OneTimeAccessTokenSharedObject.md)
+ - [Parameters](docs/Parameters.md)
+ - [ParametersUpdate](docs/ParametersUpdate.md)
+ - [ParseSAMLIDPMetadataRequest](docs/ParseSAMLIDPMetadataRequest.md)
+ - [ParsedSAMLIDPMetadata](docs/ParsedSAMLIDPMetadata.md)
+ - [PasswordResetEndpointRequest](docs/PasswordResetEndpointRequest.md)
+ - [Path](docs/Path.md)
+ - [PathInput](docs/PathInput.md)
+ - [Production](docs/Production.md)
+ - [ProductionMiniReference](docs/ProductionMiniReference.md)
+ - [ProductionPartialUpdate](docs/ProductionPartialUpdate.md)
+ - [ProductionReference](docs/ProductionReference.md)
+ - [ProductionUpdate](docs/ProductionUpdate.md)
+ - [Proxy](docs/Proxy.md)
+ - [ProxyCount](docs/ProxyCount.md)
+ - [ProxyFSSizeEndpointResponse](docs/ProxyFSSizeEndpointResponse.md)
+ - [ProxyGenerator](docs/ProxyGenerator.md)
+ - [ProxyGeneratorProperties](docs/ProxyGeneratorProperties.md)
+ - [ProxyProfile](docs/ProxyProfile.md)
+ - [ProxyProfileMini](docs/ProxyProfileMini.md)
+ - [ProxyProfilePartialUpdate](docs/ProxyProfilePartialUpdate.md)
+ - [ProxyProfileUpdate](docs/ProxyProfileUpdate.md)
+ - [PythonEnvironment](docs/PythonEnvironment.md)
+ - [Queue](docs/Queue.md)
+ - [Quota](docs/Quota.md)
+ - [RAMStat](docs/RAMStat.md)
+ - [RDCActivation](docs/RDCActivation.md)
+ - [RDCHost](docs/RDCHost.md)
+ - [RDCSession](docs/RDCSession.md)
+ - [RDCSessionCreate](docs/RDCSessionCreate.md)
+ - [RegisterUploadEndpointRequest](docs/RegisterUploadEndpointRequest.md)
+ - [RegisterUploadMetadataEndpointRequest](docs/RegisterUploadMetadataEndpointRequest.md)
+ - [ReleaseNotesEndpointResponse](docs/ReleaseNotesEndpointResponse.md)
+ - [RenameCustomFieldRequest](docs/RenameCustomFieldRequest.md)
+ - [RenderEndpointRequest](docs/RenderEndpointRequest.md)
+ - [RenderRequest](docs/RenderRequest.md)
+ - [RestoreEndpointRequest](docs/RestoreEndpointRequest.md)
+ - [SAMLProvider](docs/SAMLProvider.md)
+ - [SAMLProviderMini](docs/SAMLProviderMini.md)
+ - [SAMLProviderPartialUpdate](docs/SAMLProviderPartialUpdate.md)
+ - [SAMLProviderUpdate](docs/SAMLProviderUpdate.md)
+ - [SMTPConfiguration](docs/SMTPConfiguration.md)
+ - [SMTPConfigurationUpdate](docs/SMTPConfigurationUpdate.md)
+ - [SNFSStripeGroup](docs/SNFSStripeGroup.md)
+ - [SavedSearch](docs/SavedSearch.md)
+ - [SavedSearchPartialUpdate](docs/SavedSearchPartialUpdate.md)
+ - [SavedSearchUpdate](docs/SavedSearchUpdate.md)
+ - [ScannerDiscoverEndpointRequest](docs/ScannerDiscoverEndpointRequest.md)
+ - [ScannerScanEndpointRequest](docs/ScannerScanEndpointRequest.md)
+ - [Schedule](docs/Schedule.md)
+ - [SchedulePartialUpdate](docs/SchedulePartialUpdate.md)
+ - [ScheduleReference](docs/ScheduleReference.md)
+ - [ScheduleUpdate](docs/ScheduleUpdate.md)
+ - [SearchEndpointRequest](docs/SearchEndpointRequest.md)
+ - [SearchEndpointResponse](docs/SearchEndpointResponse.md)
+ - [SendLinkEmailRequest](docs/SendLinkEmailRequest.md)
+ - [Sensor](docs/Sensor.md)
+ - [Sensors](docs/Sensors.md)
+ - [ServiceStatus](docs/ServiceStatus.md)
+ - [Share](docs/Share.md)
+ - [SharePartialUpdate](docs/SharePartialUpdate.md)
+ - [ShareToHomeWorkspaceEndpointRequest](docs/ShareToHomeWorkspaceEndpointRequest.md)
+ - [ShareUpdate](docs/ShareUpdate.md)
+ - [SlackChannel](docs/SlackChannel.md)
+ - [SlackConnection](docs/SlackConnection.md)
+ - [SlackConnectionPartialUpdate](docs/SlackConnectionPartialUpdate.md)
+ - [SlackConnectionStatus](docs/SlackConnectionStatus.md)
+ - [SlackConnectionUpdate](docs/SlackConnectionUpdate.md)
+ - [SlackEmoji](docs/SlackEmoji.md)
+ - [SlackMessage](docs/SlackMessage.md)
+ - [SlackUser](docs/SlackUser.md)
+ - [Snapshot](docs/Snapshot.md)
+ - [SnapshotPartialUpdate](docs/SnapshotPartialUpdate.md)
+ - [SnapshotUpdate](docs/SnapshotUpdate.md)
+ - [SolrReindexEndpointResponse](docs/SolrReindexEndpointResponse.md)
+ - [StartJobRequest](docs/StartJobRequest.md)
+ - [StartTaskRequest](docs/StartTaskRequest.md)
+ - [Stats](docs/Stats.md)
+ - [StorNextConnection](docs/StorNextConnection.md)
+ - [StorNextConnections](docs/StorNextConnections.md)
+ - [StorNextLicenseCheckEndpointResponse](docs/StorNextLicenseCheckEndpointResponse.md)
+ - [StorNextLicenseEndpointResponse](docs/StorNextLicenseEndpointResponse.md)
+ - [StorageNode](docs/StorageNode.md)
+ - [StorageNodeMini](docs/StorageNodeMini.md)
+ - [StorageNodeStatus](docs/StorageNodeStatus.md)
+ - [StorageRequest](docs/StorageRequest.md)
+ - [StorageResponse](docs/StorageResponse.md)
+ - [StorageRoot](docs/StorageRoot.md)
+ - [StornextLicense](docs/StornextLicense.md)
+ - [StornextManagerAttributes](docs/StornextManagerAttributes.md)
+ - [Subclip](docs/Subclip.md)
+ - [SubclipClipboardEntry](docs/SubclipClipboardEntry.md)
+ - [SubclipClipboardEntryUpdate](docs/SubclipClipboardEntryUpdate.md)
+ - [SubclipPartialUpdate](docs/SubclipPartialUpdate.md)
+ - [SubclipReference](docs/SubclipReference.md)
+ - [SubclipUpdate](docs/SubclipUpdate.md)
+ - [Subscription](docs/Subscription.md)
+ - [Subtask](docs/Subtask.md)
+ - [SubtaskPartialUpdate](docs/SubtaskPartialUpdate.md)
+ - [SubtaskReference](docs/SubtaskReference.md)
+ - [SubtaskUpdate](docs/SubtaskUpdate.md)
+ - [Subtitle](docs/Subtitle.md)
+ - [SubtitleClipboardEntry](docs/SubtitleClipboardEntry.md)
+ - [SubtitleClipboardEntryUpdate](docs/SubtitleClipboardEntryUpdate.md)
+ - [SubtitleEvent](docs/SubtitleEvent.md)
+ - [SyncTOTP](docs/SyncTOTP.md)
+ - [SyncTOTPRequest](docs/SyncTOTPRequest.md)
+ - [SystemInfoEndpointResponse](docs/SystemInfoEndpointResponse.md)
+ - [TagMediaDirectoryRequest](docs/TagMediaDirectoryRequest.md)
+ - [TagReference](docs/TagReference.md)
+ - [Tape](docs/Tape.md)
+ - [TapeFile](docs/TapeFile.md)
+ - [TapeGroup](docs/TapeGroup.md)
+ - [TapeGroupPartialUpdate](docs/TapeGroupPartialUpdate.md)
+ - [TapeGroupUpdate](docs/TapeGroupUpdate.md)
+ - [TapeJob](docs/TapeJob.md)
+ - [TapeJobSource](docs/TapeJobSource.md)
+ - [TapeLibraryEndpointResponse](docs/TapeLibraryEndpointResponse.md)
+ - [TapeLibraryFormatEndpointRequest](docs/TapeLibraryFormatEndpointRequest.md)
+ - [TapeLibraryFsckEndpointRequest](docs/TapeLibraryFsckEndpointRequest.md)
+ - [TapeLibraryLoadEndpointRequest](docs/TapeLibraryLoadEndpointRequest.md)
+ - [TapeLibraryMoveEndpointRequest](docs/TapeLibraryMoveEndpointRequest.md)
+ - [TapeLibraryReindexEndpointRequest](docs/TapeLibraryReindexEndpointRequest.md)
+ - [TapeLibrarySlot](docs/TapeLibrarySlot.md)
+ - [TapeLibraryUnloadEndpointRequest](docs/TapeLibraryUnloadEndpointRequest.md)
+ - [TapePartialUpdate](docs/TapePartialUpdate.md)
+ - [TapeReference](docs/TapeReference.md)
+ - [TapeUpdate](docs/TapeUpdate.md)
+ - [TaskInfo](docs/TaskInfo.md)
+ - [TaskLog](docs/TaskLog.md)
+ - [TaskProgress](docs/TaskProgress.md)
+ - [TaskType](docs/TaskType.md)
+ - [TasksSummary](docs/TasksSummary.md)
+ - [TeamsConnection](docs/TeamsConnection.md)
+ - [TeamsConnectionPartialUpdate](docs/TeamsConnectionPartialUpdate.md)
+ - [TeamsConnectionStatus](docs/TeamsConnectionStatus.md)
+ - [TeamsConnectionUpdate](docs/TeamsConnectionUpdate.md)
+ - [TeamsMessage](docs/TeamsMessage.md)
+ - [TeamsRecipient](docs/TeamsRecipient.md)
+ - [TestAWSCredentialsRequest](docs/TestAWSCredentialsRequest.md)
+ - [TestAWSCredentialsResponse](docs/TestAWSCredentialsResponse.md)
+ - [TestCloudAccountCredentialsRequest](docs/TestCloudAccountCredentialsRequest.md)
+ - [TestCloudAccountCredentialsResponse](docs/TestCloudAccountCredentialsResponse.md)
+ - [TestExternalTranscoderConnectionRequest](docs/TestExternalTranscoderConnectionRequest.md)
+ - [TestExternalTranscoderConnectionResponse](docs/TestExternalTranscoderConnectionResponse.md)
+ - [TestSMTP](docs/TestSMTP.md)
+ - [Ticket](docs/Ticket.md)
+ - [TimeEndpointRequest](docs/TimeEndpointRequest.md)
+ - [TimeEndpointResponse](docs/TimeEndpointResponse.md)
+ - [TimeSyncEndpointRequest](docs/TimeSyncEndpointRequest.md)
+ - [TimeSyncEndpointResponse](docs/TimeSyncEndpointResponse.md)
+ - [TimelineExportRequest](docs/TimelineExportRequest.md)
+ - [Timezone](docs/Timezone.md)
+ - [TraceNode](docs/TraceNode.md)
+ - [TranscoderProfile](docs/TranscoderProfile.md)
+ - [TypeDocumentation](docs/TypeDocumentation.md)
+ - [UnfilteredTag](docs/UnfilteredTag.md)
+ - [UnfilteredTagPartialUpdate](docs/UnfilteredTagPartialUpdate.md)
+ - [UnfilteredTagUpdate](docs/UnfilteredTagUpdate.md)
+ - [UpdateQuotaRequest](docs/UpdateQuotaRequest.md)
+ - [UploadAIImageRequest](docs/UploadAIImageRequest.md)
+ - [UploadChunkEndpointRequest](docs/UploadChunkEndpointRequest.md)
+ - [UploadImageEndpointRequest](docs/UploadImageEndpointRequest.md)
+ - [UserPreviewRequest](docs/UserPreviewRequest.md)
+ - [UserPreviewResponse](docs/UserPreviewResponse.md)
+ - [VantageWorkflow](docs/VantageWorkflow.md)
+ - [VantageWorkflows](docs/VantageWorkflows.md)
+ - [VeritoneConnection](docs/VeritoneConnection.md)
+ - [VeritoneEngineList](docs/VeritoneEngineList.md)
+ - [VeritoneJobList](docs/VeritoneJobList.md)
+ - [VeritoneMetadata](docs/VeritoneMetadata.md)
+ - [VeritoneUploadRequest](docs/VeritoneUploadRequest.md)
+ - [Volume](docs/Volume.md)
+ - [VolumeBeeGFSStatus](docs/VolumeBeeGFSStatus.md)
+ - [VolumeLizardFSStatus](docs/VolumeLizardFSStatus.md)
+ - [VolumeMini](docs/VolumeMini.md)
+ - [VolumeMiniReference](docs/VolumeMiniReference.md)
+ - [VolumePartialUpdate](docs/VolumePartialUpdate.md)
+ - [VolumeReference](docs/VolumeReference.md)
+ - [VolumeSNFSStatus](docs/VolumeSNFSStatus.md)
+ - [VolumeStat](docs/VolumeStat.md)
+ - [VolumeStats](docs/VolumeStats.md)
+ - [VolumeStatus](docs/VolumeStatus.md)
+ - [VolumeUpdate](docs/VolumeUpdate.md)
+ - [WorkflowTransitionRequest](docs/WorkflowTransitionRequest.md)
+ - [WorkflowTransitionResponse](docs/WorkflowTransitionResponse.md)
+ - [Workspace](docs/Workspace.md)
+ - [WorkspaceCheckIn](docs/WorkspaceCheckIn.md)
+ - [WorkspaceDetail](docs/WorkspaceDetail.md)
+ - [WorkspaceDetailPartialUpdate](docs/WorkspaceDetailPartialUpdate.md)
+ - [WorkspaceDetailUpdate](docs/WorkspaceDetailUpdate.md)
+ - [WorkspaceEndpoint](docs/WorkspaceEndpoint.md)
+ - [WorkspaceMoveToRequest](docs/WorkspaceMoveToRequest.md)
+ - [WorkspacePermission](docs/WorkspacePermission.md)
+ - [WorkspacePermissionPartialUpdate](docs/WorkspacePermissionPartialUpdate.md)
+ - [WorkspacePermissionUpdate](docs/WorkspacePermissionUpdate.md)
+ - [WorkspaceResolvedPermission](docs/WorkspaceResolvedPermission.md)
+ - [Workstation](docs/Workstation.md)
+ - [WorkstationMini](docs/WorkstationMini.md)
+ - [WorkstationPartialUpdate](docs/WorkstationPartialUpdate.md)
+ - [WorkstationUpdate](docs/WorkstationUpdate.md)
 
 

--- a/docs/AIAnnotation.md
+++ b/docs/AIAnnotation.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **track** | **str** |  | [optional] 
 **created_by** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIAnnotationCreateRequest.md
+++ b/docs/AIAnnotationCreateRequest.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **relative_width** | **float** |  | 
 **relative_height** | **float** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIAnnotationPartialUpdate.md
+++ b/docs/AIAnnotationPartialUpdate.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **track** | **str** |  | [optional] 
 **created_by** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIAnnotationUpdate.md
+++ b/docs/AIAnnotationUpdate.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **track** | **str** |  | [optional] 
 **created_by** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIApi.md
+++ b/docs/AIApi.md
@@ -96,7 +96,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **activate_ai_model**
     def activate_ai_model(id)
@@ -144,7 +144,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_ai_annotation_track**
     def [AIAnnotation] create_ai_annotation_track(ai_annotation_create_request)
@@ -203,7 +203,7 @@ Name | Type | Description  | Notes
 
 [**[AIAnnotation]**](AIAnnotation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_ai_category**
     def AICategoryDetail create_ai_category(ai_category_detail_update)
@@ -299,7 +299,7 @@ Name | Type | Description  | Notes
 
 [**AICategoryDetail**](AICategoryDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_ai_dataset**
     def AIDatasetWithPreview create_ai_dataset(ai_dataset_with_preview_update)
@@ -354,7 +354,7 @@ Name | Type | Description  | Notes
 
 [**AIDatasetWithPreview**](AIDatasetWithPreview.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_ai_dataset_model**
     def AIModel create_ai_dataset_model(ai_model_training_request)
@@ -415,7 +415,7 @@ Name | Type | Description  | Notes
 
 [**AIModel**](AIModel.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_ai_metadata**
     def create_ai_metadata(ai_processing_request)
@@ -475,7 +475,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_ai_model**
     def AIModel create_ai_model(ai_model_update)
@@ -538,7 +538,7 @@ Name | Type | Description  | Notes
 
 [**AIModel**](AIModel.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_ai_annotation**
     def delete_ai_annotation(id)
@@ -586,7 +586,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_ai_annotation_track**
     def delete_ai_annotation_track(id)
@@ -634,7 +634,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_ai_category**
     def delete_ai_category(id)
@@ -682,7 +682,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_ai_dataset**
     def delete_ai_dataset(id)
@@ -730,7 +730,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_ai_model**
     def delete_ai_model(id)
@@ -778,7 +778,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **export_ai_dataset**
     def AIDatasetExportResponse export_ai_dataset(id, ai_dataset_export_request)
@@ -833,7 +833,7 @@ Name | Type | Description  | Notes
 
 [**AIDatasetExportResponse**](AIDatasetExportResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **export_ai_model**
     def AIModelExportResponse export_ai_model(id, ai_model_export_request)
@@ -888,7 +888,7 @@ Name | Type | Description  | Notes
 
 [**AIModelExportResponse**](AIModelExportResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ai_annotation**
     def AIAnnotation get_ai_annotation(id)
@@ -948,7 +948,7 @@ Name | Type | Description  | Notes
 
 [**AIAnnotation**](AIAnnotation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ai_annotation_image**
     def get_ai_annotation_image(id)
@@ -996,7 +996,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ai_category**
     def AICategoryDetail get_ai_category(id)
@@ -1046,7 +1046,7 @@ Name | Type | Description  | Notes
 
 [**AICategoryDetail**](AICategoryDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ai_connection**
     def AIConnection get_ai_connection(id)
@@ -1096,7 +1096,7 @@ Name | Type | Description  | Notes
 
 [**AIConnection**](AIConnection.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ai_dataset**
     def AIDatasetWithPreview get_ai_dataset(id)
@@ -1146,7 +1146,7 @@ Name | Type | Description  | Notes
 
 [**AIDatasetWithPreview**](AIDatasetWithPreview.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ai_image**
     def AIImage get_ai_image(id)
@@ -1196,7 +1196,7 @@ Name | Type | Description  | Notes
 
 [**AIImage**](AIImage.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ai_image_content**
     def get_ai_image_content(id)
@@ -1244,7 +1244,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ai_metadata**
     def AIMetadata get_ai_metadata(id)
@@ -1294,7 +1294,7 @@ Name | Type | Description  | Notes
 
 [**AIMetadata**](AIMetadata.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ai_model**
     def AIModel get_ai_model(id)
@@ -1344,7 +1344,7 @@ Name | Type | Description  | Notes
 
 [**AIModel**](AIModel.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_ai_annotation_tracks**
     def [AIAnnotation] get_all_ai_annotation_tracks()
@@ -1407,7 +1407,7 @@ Name | Type | Description  | Notes
 
 [**[AIAnnotation]**](AIAnnotation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_ai_annotations**
     def [AIAnnotation] get_all_ai_annotations()
@@ -1474,7 +1474,7 @@ Name | Type | Description  | Notes
 
 [**[AIAnnotation]**](AIAnnotation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_ai_categories**
     def [AICategory] get_all_ai_categories()
@@ -1533,7 +1533,7 @@ Name | Type | Description  | Notes
 
 [**[AICategory]**](AICategory.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_ai_connections**
     def [AIConnection] get_all_ai_connections()
@@ -1588,7 +1588,7 @@ Name | Type | Description  | Notes
 
 [**[AIConnection]**](AIConnection.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_ai_datasets**
     def [AIDatasetWithPreview] get_all_ai_datasets()
@@ -1647,7 +1647,7 @@ Name | Type | Description  | Notes
 
 [**[AIDatasetWithPreview]**](AIDatasetWithPreview.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_ai_images**
     def [AIImage] get_all_ai_images()
@@ -1704,7 +1704,7 @@ Name | Type | Description  | Notes
 
 [**[AIImage]**](AIImage.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_ai_metadata**
     def [AIMetadata] get_all_ai_metadata()
@@ -1763,7 +1763,7 @@ Name | Type | Description  | Notes
 
 [**[AIMetadata]**](AIMetadata.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_ai_models**
     def [AIModel] get_all_ai_models()
@@ -1820,7 +1820,7 @@ Name | Type | Description  | Notes
 
 [**[AIModel]**](AIModel.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **import_ai_datasets**
     def ImportAIDatasetResponse import_ai_datasets(import_ai_dataset_request)
@@ -1876,7 +1876,7 @@ Name | Type | Description  | Notes
 
 [**ImportAIDatasetResponse**](ImportAIDatasetResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **import_ai_models**
     def ImportAIModelResponse import_ai_models(id, import_ai_model_request)
@@ -1931,7 +1931,7 @@ Name | Type | Description  | Notes
 
 [**ImportAIModelResponse**](ImportAIModelResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_ai_annotation**
     def AIAnnotation patch_ai_annotation(id, ai_annotation_partial_update)
@@ -1997,7 +1997,7 @@ Name | Type | Description  | Notes
 
 [**AIAnnotation**](AIAnnotation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_ai_category**
     def AICategoryDetail patch_ai_category(id, ai_category_detail_partial_update)
@@ -2095,7 +2095,7 @@ Name | Type | Description  | Notes
 
 [**AICategoryDetail**](AICategoryDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_ai_dataset**
     def AIDatasetWithPreview patch_ai_dataset(id, ai_dataset_with_preview_partial_update)
@@ -2152,7 +2152,7 @@ Name | Type | Description  | Notes
 
 [**AIDatasetWithPreview**](AIDatasetWithPreview.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_ai_model**
     def AIModel patch_ai_model(id, ai_model_partial_update)
@@ -2217,7 +2217,7 @@ Name | Type | Description  | Notes
 
 [**AIModel**](AIModel.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **run_ai_model_inference**
     def AIModelInferenceResponse run_ai_model_inference(id, ai_model_inference_request)
@@ -2277,7 +2277,7 @@ Name | Type | Description  | Notes
 
 [**AIModelInferenceResponse**](AIModelInferenceResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_ai_annotation**
     def AIAnnotation update_ai_annotation(id, ai_annotation_update)
@@ -2343,7 +2343,7 @@ Name | Type | Description  | Notes
 
 [**AIAnnotation**](AIAnnotation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_ai_category**
     def AICategoryDetail update_ai_category(id, ai_category_detail_update)
@@ -2441,7 +2441,7 @@ Name | Type | Description  | Notes
 
 [**AICategoryDetail**](AICategoryDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_ai_dataset**
     def AIDatasetWithPreview update_ai_dataset(id, ai_dataset_with_preview_update)
@@ -2498,7 +2498,7 @@ Name | Type | Description  | Notes
 
 [**AIDatasetWithPreview**](AIDatasetWithPreview.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_ai_model**
     def AIModel update_ai_model(id, ai_model_update)
@@ -2563,7 +2563,7 @@ Name | Type | Description  | Notes
 
 [**AIModel**](AIModel.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **upload_ai_image**
     def AIImage upload_ai_image(upload_ai_image_request)
@@ -2617,5 +2617,5 @@ Name | Type | Description  | Notes
 
 [**AIImage**](AIImage.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/AICategory.md
+++ b/docs/AICategory.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **dataset** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AICategoryDetail.md
+++ b/docs/AICategoryDetail.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **dataset** | [**AIDatasetDetailReference**](AIDatasetDetailReference.md) |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AICategoryDetailPartialUpdate.md
+++ b/docs/AICategoryDetailPartialUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **dataset** | [**AIDatasetDetailReference**](AIDatasetDetailReference.md) |  | [optional] 
 **name** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AICategoryDetailUpdate.md
+++ b/docs/AICategoryDetailUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **dataset** | [**AIDatasetDetailReference**](AIDatasetDetailReference.md) |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AICategoryMiniReference.md
+++ b/docs/AICategoryMiniReference.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **id** | **str** |  | 
 **name** | **str** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIConnection.md
+++ b/docs/AIConnection.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **id** | **int** |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIDataset.md
+++ b/docs/AIDataset.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **connection** | **int** |  | 
 **type** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIDatasetDetailReference.md
+++ b/docs/AIDatasetDetailReference.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **type** | **str** |  | [optional] [readonly] 
 **connection** | **int** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIDatasetExportRequest.md
+++ b/docs/AIDatasetExportRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **path** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIDatasetExportResponse.md
+++ b/docs/AIDatasetExportResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **task** | [**TaskInfo**](TaskInfo.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIDatasetReference.md
+++ b/docs/AIDatasetReference.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **type** | **str** |  | [optional] [readonly] 
 **connection** | **int** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIDatasetSimple.md
+++ b/docs/AIDatasetSimple.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **engine** | **str** |  | [optional] 
 **connection** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIDatasetWithPreview.md
+++ b/docs/AIDatasetWithPreview.md
@@ -15,6 +15,6 @@ Name | Type | Description | Notes
 **last_finished_model** | [**AIModel**](AIModel.md) |  | [optional] 
 **type** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIDatasetWithPreviewPartialUpdate.md
+++ b/docs/AIDatasetWithPreviewPartialUpdate.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **type** | **str** |  | [optional] 
 **connection** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIDatasetWithPreviewUpdate.md
+++ b/docs/AIDatasetWithPreviewUpdate.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **connection** | **int** |  | 
 **type** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIImage.md
+++ b/docs/AIImage.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **proxy** | **int, none_type** |  | [optional] 
 **filename** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIImageReference.md
+++ b/docs/AIImageReference.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **width** | **int** |  | [optional] [readonly] 
 **height** | **int** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIMetadata.md
+++ b/docs/AIMetadata.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **metadata** | **{str: (bool, date, datetime, dict, float, int, list, str, none_type)}** |  | 
 **type** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIModel.md
+++ b/docs/AIModel.md
@@ -19,6 +19,6 @@ Name | Type | Description | Notes
 **epoch** | **int, none_type** |  | [optional] 
 **preprocessing_task** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIModelExportRequest.md
+++ b/docs/AIModelExportRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **path** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIModelExportResponse.md
+++ b/docs/AIModelExportResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **task** | [**TaskInfo**](TaskInfo.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIModelInferenceRequest.md
+++ b/docs/AIModelInferenceRequest.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **skip_step** | **int, none_type** |  | [optional] 
 **combine_threshold** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIModelInferenceResponse.md
+++ b/docs/AIModelInferenceResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **annotations** | **[str, none_type]** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIModelPartialUpdate.md
+++ b/docs/AIModelPartialUpdate.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **epoch** | **int, none_type** |  | [optional] 
 **preprocessing_task** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIModelProgress.md
+++ b/docs/AIModelProgress.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **status** | **{str: (str, none_type)}** |  | 
 **eta** | **datetime, none_type** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIModelStat.md
+++ b/docs/AIModelStat.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **loss** | **float** |  | 
 **avg_loss** | **float** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIModelStats.md
+++ b/docs/AIModelStats.md
@@ -6,6 +6,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **stats** | [**list[AIModelStat]**](AIModelStat.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIModelTrainingRequest.md
+++ b/docs/AIModelTrainingRequest.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **categories** | **[str]** |  | [optional] 
 **continue_from** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIModelUpdate.md
+++ b/docs/AIModelUpdate.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **epoch** | **int, none_type** |  | [optional] 
 **preprocessing_task** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AIProcessingRequest.md
+++ b/docs/AIProcessingRequest.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **directories** | **[int]** |  | [optional] 
 **preferred_proxy_profile** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/APIToken.md
+++ b/docs/APIToken.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **id** | **int** |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/APITokenPartialUpdate.md
+++ b/docs/APITokenPartialUpdate.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/APITokenUpdate.md
+++ b/docs/APITokenUpdate.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/APITokenWithSecret.md
+++ b/docs/APITokenWithSecret.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **token** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/APITokenWithSecretUpdate.md
+++ b/docs/APITokenWithSecretUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **token** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AWSAccount.md
+++ b/docs/AWSAccount.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **endpoint_url** | **str** |  | [optional] 
 **default_region** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AWSAccountPartialUpdate.md
+++ b/docs/AWSAccountPartialUpdate.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **endpoint_url** | **str** |  | [optional] 
 **default_region** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AWSApi.md
+++ b/docs/AWSApi.md
@@ -66,7 +66,7 @@ Name | Type | Description  | Notes
 
 [**CloudAccountMini**](CloudAccountMini.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_aws_account**
     def delete_aws_account(id)
@@ -114,7 +114,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_aws_accounts**
     def [CloudAccountMini] get_all_aws_accounts()
@@ -173,7 +173,7 @@ Name | Type | Description  | Notes
 
 [**[CloudAccountMini]**](CloudAccountMini.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_aws_account**
     def CloudAccountMini get_aws_account(id)
@@ -223,7 +223,7 @@ Name | Type | Description  | Notes
 
 [**CloudAccountMini**](CloudAccountMini.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_aws_account_sns_topics**
     def ListTopics get_aws_account_sns_topics(id)
@@ -273,7 +273,7 @@ Name | Type | Description  | Notes
 
 [**ListTopics**](ListTopics.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_aws_account**
     def CloudAccountMini patch_aws_account(id, cloud_account_mini_partial_update)
@@ -329,7 +329,7 @@ Name | Type | Description  | Notes
 
 [**CloudAccountMini**](CloudAccountMini.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **test_aws_account_credentials**
     def TestAWSCredentialsResponse test_aws_account_credentials(test_aws_credentials_request)
@@ -383,7 +383,7 @@ Name | Type | Description  | Notes
 
 [**TestAWSCredentialsResponse**](TestAWSCredentialsResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_aws_account**
     def CloudAccountMini update_aws_account(id, cloud_account_mini_update)
@@ -439,5 +439,5 @@ Name | Type | Description  | Notes
 
 [**CloudAccountMini**](CloudAccountMini.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/AddAssetsToClickGallery.md
+++ b/docs/AddAssetsToClickGallery.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **assets** | **[str]** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Address.md
+++ b/docs/Address.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **priority** | **int** |  | [optional] 
 **interface** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Alert.md
+++ b/docs/Alert.md
@@ -15,6 +15,6 @@ Name | Type | Description | Notes
 **duration** | **str** |  | [readonly] 
 **closed_at** | **datetime, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AlertPartialUpdate.md
+++ b/docs/AlertPartialUpdate.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **is_open** | **bool** |  | [optional] 
 **closed_at** | **datetime, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AlertUpdate.md
+++ b/docs/AlertUpdate.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **is_open** | **bool** |  | 
 **closed_at** | **datetime, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AllMediaFilesForBundlesRequest.md
+++ b/docs/AllMediaFilesForBundlesRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **bundles** | **[int]** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ArchiveEndpointRequest.md
+++ b/docs/ArchiveEndpointRequest.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **export** | **bool** |  | [optional] 
 **export2** | **bool, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ArgumentType.md
+++ b/docs/ArgumentType.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **display_name** | **str** |  | [readonly] 
 **documentation** | [**[TypeDocumentation]**](TypeDocumentation.md) |  | [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Asset.md
+++ b/docs/Asset.md
@@ -35,6 +35,6 @@ Name | Type | Description | Notes
 **rating** | **int, none_type** |  | [optional] [readonly] 
 **set** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AssetBackup.md
+++ b/docs/AssetBackup.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **search_highlight** | **str** |  | [readonly] 
 **custom_fields_snapshot** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AssetCloudLink.md
+++ b/docs/AssetCloudLink.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **created_at** | **datetime** |  | [readonly] 
 **asset** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AssetMini.md
+++ b/docs/AssetMini.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **thumbnail_generated** | **bool** |  | [readonly] 
 **default_proxy** | [**Proxy**](Proxy.md) |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AssetMiniReference.md
+++ b/docs/AssetMiniReference.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **info** | **{str: (str, none_type)}** |  | [optional] [readonly] 
 **thumbnail_generated** | **bool** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AssetPartialUpdate.md
+++ b/docs/AssetPartialUpdate.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **tags** | **[int]** |  | [optional] 
 **set** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AssetProjectLink.md
+++ b/docs/AssetProjectLink.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **sequence_name** | **str** |  | 
 **asset** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AssetRating.md
+++ b/docs/AssetRating.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **asset** | **int** |  | 
 **rating** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AssetRatingPartialUpdate.md
+++ b/docs/AssetRatingPartialUpdate.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **rating** | **int** |  | [optional] 
 **asset** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AssetRatingUpdate.md
+++ b/docs/AssetRatingUpdate.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **asset** | **int** |  | 
 **rating** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AssetSubtitleLink.md
+++ b/docs/AssetSubtitleLink.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **asset** | **int** |  | 
 **id** | **int** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AssetSubtitleLinkPartialUpdate.md
+++ b/docs/AssetSubtitleLinkPartialUpdate.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **key** | **str, none_type** |  | [optional] 
 **asset** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AssetSubtitleLinkUpdate.md
+++ b/docs/AssetSubtitleLinkUpdate.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **key** | **str, none_type** |  | 
 **asset** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AssetUpdate.md
+++ b/docs/AssetUpdate.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **tags** | **[int]** |  | 
 **set** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AuthApi.md
+++ b/docs/AuthApi.md
@@ -90,7 +90,7 @@ Name | Type | Description  | Notes
 
 [**ElementsUserDetail**](ElementsUserDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_api_token**
     def APITokenWithSecret create_api_token(api_token_with_secret_update)
@@ -144,7 +144,7 @@ Name | Type | Description  | Notes
 
 [**APITokenWithSecret**](APITokenWithSecret.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_auth_ticket**
     def Ticket create_auth_ticket()
@@ -190,7 +190,7 @@ This endpoint does not need any parameter.
 
 [**Ticket**](Ticket.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_saml_provider**
     def SAMLProvider create_saml_provider(saml_provider_update)
@@ -249,7 +249,7 @@ Name | Type | Description  | Notes
 
 [**SAMLProvider**](SAMLProvider.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_access_token**
     def delete_access_token(id)
@@ -297,7 +297,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_api_token**
     def delete_api_token(id)
@@ -345,7 +345,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_saml_provider**
     def delete_saml_provider(id)
@@ -393,7 +393,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **generate_password**
     def GeneratePasswordEndpointResponse generate_password()
@@ -439,7 +439,7 @@ This endpoint does not need any parameter.
 
 [**GeneratePasswordEndpointResponse**](GeneratePasswordEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_access_token**
     def OneTimeAccessToken get_access_token(id)
@@ -489,7 +489,7 @@ Name | Type | Description  | Notes
 
 [**OneTimeAccessToken**](OneTimeAccessToken.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_access_tokens**
     def [OneTimeAccessToken] get_all_access_tokens()
@@ -554,7 +554,7 @@ Name | Type | Description  | Notes
 
 [**[OneTimeAccessToken]**](OneTimeAccessToken.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_api_tokens**
     def [APIToken] get_all_api_tokens()
@@ -611,7 +611,7 @@ Name | Type | Description  | Notes
 
 [**[APIToken]**](APIToken.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_saml_providers**
     def [SAMLProvider] get_all_saml_providers()
@@ -666,7 +666,7 @@ Name | Type | Description  | Notes
 
 [**[SAMLProvider]**](SAMLProvider.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_api_token**
     def APIToken get_api_token(id)
@@ -716,7 +716,7 @@ Name | Type | Description  | Notes
 
 [**APIToken**](APIToken.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_saml_provider**
     def SAMLProvider get_saml_provider(id)
@@ -766,7 +766,7 @@ Name | Type | Description  | Notes
 
 [**SAMLProvider**](SAMLProvider.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_saml_service_provider_metadata**
     def get_saml_service_provider_metadata(id)
@@ -812,7 +812,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **login**
     def AuthLoginEndpointResponse login(auth_login_endpoint_request)
@@ -868,7 +868,7 @@ Name | Type | Description  | Notes
 
 [**AuthLoginEndpointResponse**](AuthLoginEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **logout**
     def logout()
@@ -912,7 +912,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **logout_page**
     def logout_page()
@@ -956,7 +956,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **parse_samlidp_metadata**
     def ParsedSAMLIDPMetadata parse_samlidp_metadata(parse_samlidp_metadata_request)
@@ -1009,7 +1009,7 @@ Name | Type | Description  | Notes
 
 [**ParsedSAMLIDPMetadata**](ParsedSAMLIDPMetadata.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_api_token**
     def APIToken patch_api_token(id, api_token_partial_update)
@@ -1064,7 +1064,7 @@ Name | Type | Description  | Notes
 
 [**APIToken**](APIToken.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_saml_provider**
     def SAMLProvider patch_saml_provider(id, saml_provider_partial_update)
@@ -1125,7 +1125,7 @@ Name | Type | Description  | Notes
 
 [**SAMLProvider**](SAMLProvider.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **receive_saml_auth_assertion**
     def receive_saml_auth_assertion(id)
@@ -1171,7 +1171,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **refresh_samlidp_metadata**
     def ParsedSAMLIDPMetadata refresh_samlidp_metadata(id, parse_samlidp_metadata_request)
@@ -1226,7 +1226,7 @@ Name | Type | Description  | Notes
 
 [**ParsedSAMLIDPMetadata**](ParsedSAMLIDPMetadata.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **reset_password**
     def reset_password(password_reset_endpoint_request)
@@ -1278,7 +1278,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **return_from_saml_auth**
     def return_from_saml_auth(id)
@@ -1324,7 +1324,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **return_from_saml_logout**
     def return_from_saml_logout(id)
@@ -1370,7 +1370,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **send_access_token_email_notification**
     def send_access_token_email_notification(id, send_link_email_request)
@@ -1425,7 +1425,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **start_impersonation**
     def start_impersonation(impersonation_endpoint_request)
@@ -1476,7 +1476,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **start_saml_auth**
     def start_saml_auth(id)
@@ -1522,7 +1522,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **start_saml_logout**
     def start_saml_logout(id)
@@ -1568,7 +1568,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **stop_impersonation**
     def stop_impersonation()
@@ -1612,7 +1612,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_api_token**
     def APIToken update_api_token(id, api_token_update)
@@ -1667,7 +1667,7 @@ Name | Type | Description  | Notes
 
 [**APIToken**](APIToken.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_saml_provider**
     def SAMLProvider update_saml_provider(id, saml_provider_update)
@@ -1728,5 +1728,5 @@ Name | Type | Description  | Notes
 
 [**SAMLProvider**](SAMLProvider.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/AuthLoginEndpointRequest.md
+++ b/docs/AuthLoginEndpointRequest.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **otp** | **str, none_type** |  | [optional] 
 **new_password** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AuthLoginEndpointResponse.md
+++ b/docs/AuthLoginEndpointResponse.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **detail** | **str** |  | [optional] 
 **redirect** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/AutomationApi.md
+++ b/docs/AutomationApi.md
@@ -94,7 +94,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_job**
     def Job create_job(job_update)
@@ -185,7 +185,7 @@ Name | Type | Description  | Notes
 
 [**Job**](Job.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_schedule**
     def Schedule create_schedule(schedule_update)
@@ -251,7 +251,7 @@ Name | Type | Description  | Notes
 
 [**Schedule**](Schedule.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_subtask**
     def Subtask create_subtask(subtask_update)
@@ -323,7 +323,7 @@ Name | Type | Description  | Notes
 
 [**Subtask**](Subtask.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_finished_tasks**
     def delete_finished_tasks()
@@ -367,7 +367,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_job**
     def delete_job(id)
@@ -415,7 +415,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_schedule**
     def delete_schedule(id)
@@ -463,7 +463,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_subtask**
     def delete_subtask(id)
@@ -511,7 +511,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_task**
     def delete_task(id)
@@ -559,7 +559,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **download_all_task_logs**
     def download_all_task_logs()
@@ -630,7 +630,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **download_task_log**
     def download_task_log(id)
@@ -678,7 +678,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **export_job**
     def export_job(id)
@@ -726,7 +726,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_events**
     def [Event] get_all_events()
@@ -781,7 +781,7 @@ Name | Type | Description  | Notes
 
 [**[Event]**](Event.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_jobs**
     def [Job] get_all_jobs()
@@ -844,7 +844,7 @@ Name | Type | Description  | Notes
 
 [**[Job]**](Job.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_schedules**
     def [Schedule] get_all_schedules()
@@ -901,7 +901,7 @@ Name | Type | Description  | Notes
 
 [**[Schedule]**](Schedule.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_subtasks**
     def [Subtask] get_all_subtasks()
@@ -958,7 +958,7 @@ Name | Type | Description  | Notes
 
 [**[Subtask]**](Subtask.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_task_queues**
     def [Queue] get_all_task_queues()
@@ -1013,7 +1013,7 @@ Name | Type | Description  | Notes
 
 [**[Queue]**](Queue.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_task_types**
     def [TaskType] get_all_task_types()
@@ -1068,7 +1068,7 @@ Name | Type | Description  | Notes
 
 [**[TaskType]**](TaskType.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_tasks**
     def [TaskInfo] get_all_tasks()
@@ -1141,7 +1141,7 @@ Name | Type | Description  | Notes
 
 [**[TaskInfo]**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_event**
     def Event get_event(id)
@@ -1191,7 +1191,7 @@ Name | Type | Description  | Notes
 
 [**Event**](Event.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_finished_tasks**
     def [TaskInfo] get_finished_tasks()
@@ -1264,7 +1264,7 @@ Name | Type | Description  | Notes
 
 [**[TaskInfo]**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_job**
     def Job get_job(id)
@@ -1314,7 +1314,7 @@ Name | Type | Description  | Notes
 
 [**Job**](Job.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_pending_tasks**
     def [TaskInfo] get_pending_tasks()
@@ -1387,7 +1387,7 @@ Name | Type | Description  | Notes
 
 [**[TaskInfo]**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_python_environments**
     def [PythonEnvironment] get_python_environments()
@@ -1433,7 +1433,7 @@ This endpoint does not need any parameter.
 
 [**[PythonEnvironment]**](PythonEnvironment.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_schedule**
     def Schedule get_schedule(id)
@@ -1483,7 +1483,7 @@ Name | Type | Description  | Notes
 
 [**Schedule**](Schedule.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_subtask**
     def Subtask get_subtask(id)
@@ -1533,7 +1533,7 @@ Name | Type | Description  | Notes
 
 [**Subtask**](Subtask.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_task**
     def TaskInfo get_task(id)
@@ -1583,7 +1583,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_task_log**
     def TaskLog get_task_log(id)
@@ -1633,7 +1633,7 @@ Name | Type | Description  | Notes
 
 [**TaskLog**](TaskLog.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_task_type**
     def TaskType get_task_type(type)
@@ -1683,7 +1683,7 @@ Name | Type | Description  | Notes
 
 [**TaskType**](TaskType.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_tasks_summary**
     def TasksSummary get_tasks_summary()
@@ -1756,7 +1756,7 @@ Name | Type | Description  | Notes
 
 [**TasksSummary**](TasksSummary.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **import_job**
     def ImportJobResponse import_job(import_job_request)
@@ -1811,7 +1811,7 @@ Name | Type | Description  | Notes
 
 [**ImportJobResponse**](ImportJobResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **kill_all_pending_tasks**
     def kill_all_pending_tasks()
@@ -1855,7 +1855,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **kill_task**
     def kill_task(id)
@@ -1903,7 +1903,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_job**
     def Job patch_job(id, job_partial_update)
@@ -1996,7 +1996,7 @@ Name | Type | Description  | Notes
 
 [**Job**](Job.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_schedule**
     def Schedule patch_schedule(id, schedule_partial_update)
@@ -2064,7 +2064,7 @@ Name | Type | Description  | Notes
 
 [**Schedule**](Schedule.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_subtask**
     def Subtask patch_subtask(id, subtask_partial_update)
@@ -2138,7 +2138,7 @@ Name | Type | Description  | Notes
 
 [**Subtask**](Subtask.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **restart_task**
     def TaskInfo restart_task(id)
@@ -2188,7 +2188,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **start_job**
     def [TaskInfo] start_job(id, start_job_request)
@@ -2244,7 +2244,7 @@ Name | Type | Description  | Notes
 
 [**[TaskInfo]**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **start_task**
     def TaskInfo start_task(start_task_request)
@@ -2301,7 +2301,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_job**
     def Job update_job(id, job_update)
@@ -2394,7 +2394,7 @@ Name | Type | Description  | Notes
 
 [**Job**](Job.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_schedule**
     def Schedule update_schedule(id, schedule_update)
@@ -2462,7 +2462,7 @@ Name | Type | Description  | Notes
 
 [**Schedule**](Schedule.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_subtask**
     def Subtask update_subtask(id, subtask_update)
@@ -2536,5 +2536,5 @@ Name | Type | Description  | Notes
 
 [**Subtask**](Subtask.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/Backend.md
+++ b/docs/Backend.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **properties** | [**BackendProperties**](BackendProperties.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/BackendProperties.md
+++ b/docs/BackendProperties.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **supports_sharing_smb_custom_options** | **bool** |  | 
 **supports_sharing_nfs_permissions** | **bool** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/BasicFile.md
+++ b/docs/BasicFile.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **is_dir** | **bool** |  | [readonly] 
 **files** | **[dict], none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/BeeGFSNode.md
+++ b/docs/BeeGFSNode.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **addresses** | **[str]** |  | 
 **node** | [**StorageNodeMini**](StorageNodeMini.md) |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/BeeGFSTarget.md
+++ b/docs/BeeGFSTarget.md
@@ -16,6 +16,6 @@ Name | Type | Description | Notes
 **errors** | **[str]** |  | 
 **node** | [**StorageNodeMini**](StorageNodeMini.md) |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/BootstrapData.md
+++ b/docs/BootstrapData.md
@@ -32,6 +32,6 @@ Name | Type | Description | Notes
 **active_saml_provider** | [**SAMLProviderMini**](SAMLProviderMini.md) |  | [optional] 
 **tasks_summary** | [**TasksSummary**](TasksSummary.md) |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CPUStat.md
+++ b/docs/CPUStat.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **c_user** | **float** |  | 
 **c_usage** | **float** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Certificate.md
+++ b/docs/Certificate.md
@@ -17,6 +17,6 @@ Name | Type | Description | Notes
 **domain_matches** | **str** |  | [readonly] 
 **key** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CertificateUpdate.md
+++ b/docs/CertificateUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **certificate** | **str** |  | 
 **key** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ChangeOwnPasswordRequest.md
+++ b/docs/ChangeOwnPasswordRequest.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **password** | **str** |  | 
 **current_otp** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ChangePasswordRequest.md
+++ b/docs/ChangePasswordRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **password** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CheckConnectivityEndpointResponse.md
+++ b/docs/CheckConnectivityEndpointResponse.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **success** | **bool** |  | 
 **errors** | **[str]** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ClickApi.md
+++ b/docs/ClickApi.md
@@ -64,7 +64,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **add_assets_to_click_gallery**
     def ClickGallery add_assets_to_click_gallery(connection_id, id, add_assets_to_click_gallery)
@@ -123,7 +123,7 @@ Name | Type | Description  | Notes
 
 [**ClickGallery**](ClickGallery.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **continue_click_upload_in_background**
     def continue_click_upload_in_background(upload_id, click_background_upload_endpoint_request)
@@ -180,7 +180,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_click_gallery**
     def ClickGallery create_click_gallery(connection_id, click_gallery_update)
@@ -236,7 +236,7 @@ Name | Type | Description  | Notes
 
 [**ClickGallery**](ClickGallery.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_click_gallery_link**
     def ClickGalleryLink create_click_gallery_link(connection_id, click_gallery_link)
@@ -302,7 +302,7 @@ Name | Type | Description  | Notes
 
 [**ClickGalleryLink**](ClickGalleryLink.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_click_gallery_link**
     def delete_click_gallery_link(connection_id, id)
@@ -352,7 +352,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_click_galleries**
     def [ClickGallery] get_all_click_galleries(connection_id)
@@ -416,7 +416,7 @@ Name | Type | Description  | Notes
 
 [**[ClickGallery]**](ClickGallery.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_click_gallery_links**
     def InlineResponse200 get_all_click_gallery_links(connection_id)
@@ -480,7 +480,7 @@ Name | Type | Description  | Notes
 
 [**InlineResponse200**](InlineResponse200.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_click_gallery**
     def ClickGallery get_click_gallery(connection_id, id)
@@ -532,7 +532,7 @@ Name | Type | Description  | Notes
 
 [**ClickGallery**](ClickGallery.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_click_gallery_link**
     def ClickGalleryLink get_click_gallery_link(connection_id, id)
@@ -584,7 +584,7 @@ Name | Type | Description  | Notes
 
 [**ClickGalleryLink**](ClickGalleryLink.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **send_click_gallery_link_email**
     def send_click_gallery_link_email(connection_id, link_id)
@@ -634,7 +634,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **start_click_upload**
     def TaskInfo start_click_upload(click_start_upload_endpoint_request)
@@ -690,5 +690,5 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/ClickBackgroundUploadEndpointRequest.md
+++ b/docs/ClickBackgroundUploadEndpointRequest.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **links_to_send** | **[int]** |  | 
 **notify_on_completion** | **bool** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ClickGallery.md
+++ b/docs/ClickGallery.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **presigned_login_url** | **str** |  | [readonly] 
 **description** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ClickGalleryLink.md
+++ b/docs/ClickGalleryLink.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **elements_user** | [**ClickLinkUser**](ClickLinkUser.md) |  | [optional] 
 **secret_key** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ClickGalleryUpdate.md
+++ b/docs/ClickGalleryUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **description** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ClickLinkUser.md
+++ b/docs/ClickLinkUser.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **email** | **str, none_type** |  | 
 **display_name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ClickStartUploadEndpointRequest.md
+++ b/docs/ClickStartUploadEndpointRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **connection** | **int** |  | 
 **assets** | **[int]** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ClientSession.md
+++ b/docs/ClientSession.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **last_updated** | **datetime** |  | [readonly] 
 **workstation** | [**WorkstationMini**](WorkstationMini.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ClientSidePathEndpointRequest.md
+++ b/docs/ClientSidePathEndpointRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **server_side_path** | **str** |  | 
 **platform** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ClientSidePathEndpointResponse.md
+++ b/docs/ClientSidePathEndpointResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **client_side_url** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ClientsEndpointResponse.md
+++ b/docs/ClientsEndpointResponse.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **platform** | **str** |  | 
 **file** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CloudAccount.md
+++ b/docs/CloudAccount.md
@@ -15,6 +15,6 @@ Name | Type | Description | Notes
 **endpoint** | **str, none_type** |  | [optional] 
 **mount_credentials_management** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CloudAccountMini.md
+++ b/docs/CloudAccountMini.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **provider** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CloudAccountMiniPartialUpdate.md
+++ b/docs/CloudAccountMiniPartialUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **provider** | **str** |  | [optional] 
 **name** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CloudAccountMiniUpdate.md
+++ b/docs/CloudAccountMiniUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **provider** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CloudAccountPartialUpdate.md
+++ b/docs/CloudAccountPartialUpdate.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **endpoint** | **str, none_type** |  | [optional] 
 **mount_credentials_management** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CloudAccountUpdate.md
+++ b/docs/CloudAccountUpdate.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **endpoint** | **str, none_type** |  | [optional] 
 **mount_credentials_management** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CloudConnection.md
+++ b/docs/CloudConnection.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **url** | **str** |  | 
 **presigned_login_url** | **str** |  | [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Comment.md
+++ b/docs/Comment.md
@@ -22,6 +22,6 @@ Name | Type | Description | Notes
 **root** | **int, none_type** |  | [optional] 
 **parent** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CommentPartialUpdate.md
+++ b/docs/CommentPartialUpdate.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **root** | **int, none_type** |  | [optional] 
 **parent** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CommentUpdate.md
+++ b/docs/CommentUpdate.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **root** | **int, none_type** |  | [optional] 
 **parent** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CreateDownloadArchive.md
+++ b/docs/CreateDownloadArchive.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **proxy** | **bool** |  | [optional] 
 **for_root** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CreateHomeWorkspaceRequest.md
+++ b/docs/CreateHomeWorkspaceRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **volume** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CreatePathQuotaRequest.md
+++ b/docs/CreatePathQuotaRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **force_destroy_content** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CreateTemplateFolderEndpointRequest.md
+++ b/docs/CreateTemplateFolderEndpointRequest.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **path** | **str** |  | 
 **group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CustomField.md
+++ b/docs/CustomField.md
@@ -24,6 +24,6 @@ Name | Type | Description | Notes
 **multiple_response** | **bool** |  | [optional] 
 **help_text** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CustomFieldPartialUpdate.md
+++ b/docs/CustomFieldPartialUpdate.md
@@ -23,6 +23,6 @@ Name | Type | Description | Notes
 **multiple_response** | **bool** |  | [optional] 
 **help_text** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CustomFieldReference.md
+++ b/docs/CustomFieldReference.md
@@ -24,6 +24,6 @@ Name | Type | Description | Notes
 **multiple_response** | **bool** |  | [optional] [readonly] 
 **help_text** | **str, none_type** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/CustomFieldUpdate.md
+++ b/docs/CustomFieldUpdate.md
@@ -23,6 +23,6 @@ Name | Type | Description | Notes
 **multiple_response** | **bool** |  | [optional] 
 **help_text** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/DeletedWorkspace.md
+++ b/docs/DeletedWorkspace.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **path** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Download.md
+++ b/docs/Download.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **icon_path** | **str, none_type** |  | [optional] 
 **fa_icon** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/DownloadArchive.md
+++ b/docs/DownloadArchive.md
@@ -17,6 +17,6 @@ Name | Type | Description | Notes
 **progress_unit** | **int** |  | [optional] 
 **user** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/DownloadArchivePartialUpdate.md
+++ b/docs/DownloadArchivePartialUpdate.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **progress_unit** | **int** |  | [optional] 
 **user** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/DownloadArchiveUpdate.md
+++ b/docs/DownloadArchiveUpdate.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **progress_unit** | **int** |  | [optional] 
 **user** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/EditorProject.md
+++ b/docs/EditorProject.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **existing_file** | **int** |  | [optional] 
 **format** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/EditorProjectPartialUpdate.md
+++ b/docs/EditorProjectPartialUpdate.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **format** | **str** |  | [optional] 
 **project** | **{str: (bool, date, datetime, dict, float, int, list, str, none_type)}** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/EditorProjectUpdate.md
+++ b/docs/EditorProjectUpdate.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **existing_file** | **int** |  | [optional] 
 **format** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/EditorSubtitle.md
+++ b/docs/EditorSubtitle.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | [optional] 
 **format** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/EditorSubtitlePartialUpdate.md
+++ b/docs/EditorSubtitlePartialUpdate.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **format** | **str** |  | [optional] 
 **subtitle** | [**Subtitle**](Subtitle.md) |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/EditorSubtitleUpdate.md
+++ b/docs/EditorSubtitleUpdate.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | [optional] 
 **format** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsGroup.md
+++ b/docs/ElementsGroup.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **gid** | **int, none_type** |  | [optional] 
 **ldap** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsGroupDetail.md
+++ b/docs/ElementsGroupDetail.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **unix_groupname** | **str, none_type** |  | [optional] 
 **gid** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsGroupDetailPartialUpdate.md
+++ b/docs/ElementsGroupDetailPartialUpdate.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **unix_groupname** | **str, none_type** |  | [optional] 
 **gid** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsGroupDetailUpdate.md
+++ b/docs/ElementsGroupDetailUpdate.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **unix_groupname** | **str, none_type** |  | [optional] 
 **gid** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsGroupReference.md
+++ b/docs/ElementsGroupReference.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **ldap** | **int, none_type** |  | [optional] [readonly] 
 **members** | **[int]** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsUser.md
+++ b/docs/ElementsUser.md
@@ -42,6 +42,6 @@ Name | Type | Description | Notes
 **uid** | **int, none_type** |  | [optional] 
 **unix_username** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsUserDetail.md
+++ b/docs/ElementsUserDetail.md
@@ -43,6 +43,6 @@ Name | Type | Description | Notes
 **uid** | **int, none_type** |  | [optional] 
 **unix_username** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsUserDetailPartialUpdate.md
+++ b/docs/ElementsUserDetailPartialUpdate.md
@@ -33,6 +33,6 @@ Name | Type | Description | Notes
 **username** | **str** |  | [optional] 
 **groups** | **[int]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsUserDetailUpdate.md
+++ b/docs/ElementsUserDetailUpdate.md
@@ -33,6 +33,6 @@ Name | Type | Description | Notes
 **uid** | **int, none_type** |  | [optional] 
 **unix_username** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsUserMini.md
+++ b/docs/ElementsUserMini.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **is_external** | **bool** |  | [optional] 
 **is_cloud** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsUserMiniReference.md
+++ b/docs/ElementsUserMiniReference.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **is_cloud** | **bool** |  | [optional] [readonly] 
 **username** | **str** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsUserProfile.md
+++ b/docs/ElementsUserProfile.md
@@ -20,6 +20,6 @@ Name | Type | Description | Notes
 **language** | **str, none_type** |  | [optional] 
 **fm_bookmarks** | **[str, none_type]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsUserProfilePartialUpdate.md
+++ b/docs/ElementsUserProfilePartialUpdate.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **language** | **str, none_type** |  | [optional] 
 **fm_bookmarks** | **[str, none_type]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsUserProfileUpdate.md
+++ b/docs/ElementsUserProfileUpdate.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **language** | **str, none_type** |  | [optional] 
 **fm_bookmarks** | **[str, none_type]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsUserReference.md
+++ b/docs/ElementsUserReference.md
@@ -42,6 +42,6 @@ Name | Type | Description | Notes
 **unix_username** | **str, none_type** |  | [optional] [readonly] 
 **username** | **str** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ElementsVersion.md
+++ b/docs/ElementsVersion.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **patch_count** | **int** |  | 
 **patch_commit_count** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/EmailPreview.md
+++ b/docs/EmailPreview.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **styling** | **{str: (str, none_type)}** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/EnableTOTPRequest.md
+++ b/docs/EnableTOTPRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **key** | **str** |  | 
 **otp** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Event.md
+++ b/docs/Event.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **license_component** | **str** |  | 
 **arg_types** | **{str: (str, none_type)}** |  | [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ExternalTranscoder.md
+++ b/docs/ExternalTranscoder.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **address** | **str** |  | 
 **type** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ExternalTranscoderPartialUpdate.md
+++ b/docs/ExternalTranscoderPartialUpdate.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **type** | **str** |  | [optional] 
 **address** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ExternalTranscoderUpdate.md
+++ b/docs/ExternalTranscoderUpdate.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **address** | **str** |  | 
 **type** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ExtractRequest.md
+++ b/docs/ExtractRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **stream** | **int** |  | 
 **destination** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FSProperties.md
+++ b/docs/FSProperties.md
@@ -15,6 +15,6 @@ Name | Type | Description | Notes
 **creating_directory_quota_destroys_content** | **bool** |  | 
 **removing_directory_quota_destroys_content** | **bool** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/File.md
+++ b/docs/File.md
@@ -34,6 +34,6 @@ Name | Type | Description | Notes
 **mode_others_write** | **bool** |  | [optional] 
 **mode_others_execute** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FileCopyEndpointRequest.md
+++ b/docs/FileCopyEndpointRequest.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **overwrite** | **str** |  | [optional] 
 **folders** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FileDeleteEndpointRequest.md
+++ b/docs/FileDeleteEndpointRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **input** | **[str]** |  | 
 **sync** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FileMoveEndpointRequest.md
+++ b/docs/FileMoveEndpointRequest.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **sync** | **bool** |  | [optional] 
 **overwrite** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FilePartialUpdate.md
+++ b/docs/FilePartialUpdate.md
@@ -28,6 +28,6 @@ Name | Type | Description | Notes
 **mode_others_write** | **bool** |  | [optional] 
 **mode_others_execute** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FileSizeDistribution.md
+++ b/docs/FileSizeDistribution.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **distribution** | [**[FileSizeDistributionItem]**](FileSizeDistributionItem.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FileSizeDistributionItem.md
+++ b/docs/FileSizeDistributionItem.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **average** | **int** |  | 
 **total** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FileSizeEndpointResponse.md
+++ b/docs/FileSizeEndpointResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **total_size** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FileUnzipEndpointRequest.md
+++ b/docs/FileUnzipEndpointRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **input** | **str** |  | 
 **remove** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FileUpdate.md
+++ b/docs/FileUpdate.md
@@ -28,6 +28,6 @@ Name | Type | Description | Notes
 **mode_others_write** | **bool** |  | [optional] 
 **mode_others_execute** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FileZipEndpointRequest.md
+++ b/docs/FileZipEndpointRequest.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **path** | **str** |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FilesystemFile.md
+++ b/docs/FilesystemFile.md
@@ -35,6 +35,6 @@ Name | Type | Description | Notes
 **mode_others_write** | **bool** |  | [optional] 
 **mode_others_execute** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FilesystemPermission.md
+++ b/docs/FilesystemPermission.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **user** | **int, none_type** |  | [optional] 
 **group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FilesystemPermissionPartialUpdate.md
+++ b/docs/FilesystemPermissionPartialUpdate.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **user** | **int, none_type** |  | [optional] 
 **group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FilesystemPermissionUpdate.md
+++ b/docs/FilesystemPermissionUpdate.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **user** | **int, none_type** |  | [optional] 
 **group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FilesystemTraceEndpointRequest.md
+++ b/docs/FilesystemTraceEndpointRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **duration** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FilesystemTraceEndpointResponse.md
+++ b/docs/FilesystemTraceEndpointResponse.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **disk_d_write** | **int** |  | 
 **is_flat** | **bool** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FinishUploadEndpointRequest.md
+++ b/docs/FinishUploadEndpointRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **upload_id** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/FormatMetadata.md
+++ b/docs/FormatMetadata.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **framerate** | **str, none_type** |  | [optional] [readonly] 
 **duration** | **float, none_type** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/GeneratePasswordEndpointResponse.md
+++ b/docs/GeneratePasswordEndpointResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **password** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/GenerateProxiesRequest.md
+++ b/docs/GenerateProxiesRequest.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **enqueue_at_front** | **bool** |  | [optional] 
 **force** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/GetMultipleBundlesRequest.md
+++ b/docs/GetMultipleBundlesRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **bundles** | **[int]** |  | [optional] 
 **files** | **[int]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/GetMultipleFilesRequest.md
+++ b/docs/GetMultipleFilesRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **files** | **[int]** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/GlobalAlert.md
+++ b/docs/GlobalAlert.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **text** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/HelpEndpointResponse.md
+++ b/docs/HelpEndpointResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **page** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/IOStat.md
+++ b/docs/IOStat.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **c_read** | **float** |  | 
 **c_write** | **float** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ImpersonationEndpointRequest.md
+++ b/docs/ImpersonationEndpointRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **user** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ImportAIDatasetRequest.md
+++ b/docs/ImportAIDatasetRequest.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **replace** | **bool** |  | 
 **rename** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ImportAIDatasetResponse.md
+++ b/docs/ImportAIDatasetResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **datasets** | [**[AIDataset]**](AIDataset.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ImportAIModelRequest.md
+++ b/docs/ImportAIModelRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **path** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ImportAIModelResponse.md
+++ b/docs/ImportAIModelResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **models** | [**[AIModel]**](AIModel.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ImportJobRequest.md
+++ b/docs/ImportJobRequest.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **replace** | **bool** |  | 
 **rename** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ImportJobResponse.md
+++ b/docs/ImportJobResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **jobs** | [**[Job]**](Job.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/InlineResponse200.md
+++ b/docs/InlineResponse200.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **next** | **str, none_type** |  | [optional] 
 **previous** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/InlineResponse2001.md
+++ b/docs/InlineResponse2001.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **previous** | **str** |  | [optional] 
 **results** | [**list[ClickGalleryLink]**](ClickGalleryLink.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/InlineResponse2002.md
+++ b/docs/InlineResponse2002.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **previous** | **str** |  | [optional] 
 **results** | [**list[Event]**](Event.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/InlineResponse2003.md
+++ b/docs/InlineResponse2003.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **previous** | **str** |  | [optional] 
 **results** | [**list[Queue]**](Queue.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/InlineResponse2004.md
+++ b/docs/InlineResponse2004.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **previous** | **str** |  | [optional] 
 **results** | [**list[TaskType]**](TaskType.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/InstallLicenseEndpointRequest.md
+++ b/docs/InstallLicenseEndpointRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **license** | **str** |  | 
 **signature** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/InstantiateFileTemplateRequest.md
+++ b/docs/InstantiateFileTemplateRequest.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **custom_fields** | **{str: (str, none_type)}** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/IntegrationsApi.md
+++ b/docs/IntegrationsApi.md
@@ -73,7 +73,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_teams_connection**
     def delete_teams_connection(id)
@@ -121,7 +121,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_slack_connections**
     def [SlackConnection] get_all_slack_connections()
@@ -176,7 +176,7 @@ Name | Type | Description  | Notes
 
 [**[SlackConnection]**](SlackConnection.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_teams_connections**
     def [TeamsConnection] get_all_teams_connections()
@@ -231,7 +231,7 @@ Name | Type | Description  | Notes
 
 [**[TeamsConnection]**](TeamsConnection.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_slack_channels**
     def [SlackChannel] get_slack_channels(id)
@@ -281,7 +281,7 @@ Name | Type | Description  | Notes
 
 [**[SlackChannel]**](SlackChannel.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_slack_connection**
     def SlackConnection get_slack_connection(id)
@@ -331,7 +331,7 @@ Name | Type | Description  | Notes
 
 [**SlackConnection**](SlackConnection.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_slack_emoji**
     def [SlackEmoji] get_slack_emoji(id)
@@ -381,7 +381,7 @@ Name | Type | Description  | Notes
 
 [**[SlackEmoji]**](SlackEmoji.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_slack_users**
     def [SlackUser] get_slack_users(id)
@@ -431,7 +431,7 @@ Name | Type | Description  | Notes
 
 [**[SlackUser]**](SlackUser.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_teams_channels**
     def [TeamsRecipient] get_teams_channels(id)
@@ -481,7 +481,7 @@ Name | Type | Description  | Notes
 
 [**[TeamsRecipient]**](TeamsRecipient.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_teams_connection**
     def TeamsConnection get_teams_connection(id)
@@ -531,7 +531,7 @@ Name | Type | Description  | Notes
 
 [**TeamsConnection**](TeamsConnection.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_teams_users**
     def [TeamsRecipient] get_teams_users(id)
@@ -581,7 +581,7 @@ Name | Type | Description  | Notes
 
 [**[TeamsRecipient]**](TeamsRecipient.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_slack_connection**
     def SlackConnection patch_slack_connection(id, slack_connection_partial_update)
@@ -636,7 +636,7 @@ Name | Type | Description  | Notes
 
 [**SlackConnection**](SlackConnection.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_teams_connection**
     def TeamsConnection patch_teams_connection(id, teams_connection_partial_update)
@@ -691,7 +691,7 @@ Name | Type | Description  | Notes
 
 [**TeamsConnection**](TeamsConnection.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **send_slack_message**
     def send_slack_message(id, slack_message)
@@ -747,7 +747,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **send_teams_message**
     def send_teams_message(id, teams_message)
@@ -801,7 +801,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **start_slack_connection_flow**
     def start_slack_connection_flow()
@@ -854,7 +854,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **start_slack_connection_token_refresh_flow**
     def start_slack_connection_token_refresh_flow(id)
@@ -902,7 +902,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **start_teams_connection_flow**
     def start_teams_connection_flow()
@@ -957,7 +957,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **start_teams_connection_token_refresh_flow**
     def start_teams_connection_token_refresh_flow(id)
@@ -1014,7 +1014,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_slack_connection**
     def SlackConnection update_slack_connection(id, slack_connection_update)
@@ -1069,7 +1069,7 @@ Name | Type | Description  | Notes
 
 [**SlackConnection**](SlackConnection.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_teams_connection**
     def TeamsConnection update_teams_connection(id, teams_connection_update)
@@ -1124,5 +1124,5 @@ Name | Type | Description  | Notes
 
 [**TeamsConnection**](TeamsConnection.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/Interface.md
+++ b/docs/Interface.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **priority** | **int** |  | [optional] 
 **port** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Ipmi.md
+++ b/docs/Ipmi.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **netmask** | **str** |  | 
 **gateway** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Job.md
+++ b/docs/Job.md
@@ -26,6 +26,6 @@ Name | Type | Description | Notes
 **security_context** | **int, none_type** |  | [optional] 
 **part_of_workflow_for** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/JobPartialUpdate.md
+++ b/docs/JobPartialUpdate.md
@@ -23,6 +23,6 @@ Name | Type | Description | Notes
 **security_context** | **int, none_type** |  | [optional] 
 **part_of_workflow_for** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/JobReference.md
+++ b/docs/JobReference.md
@@ -26,6 +26,6 @@ Name | Type | Description | Notes
 **security_context** | **int, none_type** |  | [optional] [readonly] 
 **part_of_workflow_for** | **int, none_type** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/JobUpdate.md
+++ b/docs/JobUpdate.md
@@ -23,6 +23,6 @@ Name | Type | Description | Notes
 **security_context** | **int, none_type** |  | [optional] 
 **part_of_workflow_for** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/KapacitorAlert.md
+++ b/docs/KapacitorAlert.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **details** | **str** |  | 
 **data** | **{str: (str, none_type)}** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/LDAPServer.md
+++ b/docs/LDAPServer.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | [optional] 
 **nt_domain** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/LDAPServerGroup.md
+++ b/docs/LDAPServerGroup.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **users** | [**[LDAPServerUser]**](LDAPServerUser.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/LDAPServerGroups.md
+++ b/docs/LDAPServerGroups.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **groups** | [**[LDAPServerGroup]**](LDAPServerGroup.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/LDAPServerReference.md
+++ b/docs/LDAPServerReference.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **winbind_separator** | **str** |  | [optional] [readonly] 
 **nt_domain** | **str** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/LDAPServerUser.md
+++ b/docs/LDAPServerUser.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **username** | **str** |  | 
 **mail** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/LDAPServerUsers.md
+++ b/docs/LDAPServerUsers.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **users** | [**[LDAPServerUser]**](LDAPServerUser.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/License.md
+++ b/docs/License.md
@@ -19,6 +19,6 @@ Name | Type | Description | Notes
 **hardware** | **str** |  | [optional] 
 **hardware_key** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ListBuckets.md
+++ b/docs/ListBuckets.md
@@ -6,6 +6,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **buckets** | **list[str]** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ListTopics.md
+++ b/docs/ListTopics.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **topics** | **[str]** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/LizardFSDisk.md
+++ b/docs/LizardFSDisk.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **chunks** | **int** |  | 
 **node** | [**StorageNodeMini**](StorageNodeMini.md) |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/LizardFSNode.md
+++ b/docs/LizardFSNode.md
@@ -16,6 +16,6 @@ Name | Type | Description | Notes
 **label** | **str** |  | 
 **node** | [**StorageNodeMini**](StorageNodeMini.md) |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/LocaleEndpointResponse.md
+++ b/docs/LocaleEndpointResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **strings** | **{str: (str, none_type)}** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/LocateEndpointRequest.md
+++ b/docs/LocateEndpointRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **path** | **str** |  | [optional] 
 **asset** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/LocateProxiesEndpointRequest.md
+++ b/docs/LocateProxiesEndpointRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **paths** | **[str]** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/LocateProxiesEndpointResponse.md
+++ b/docs/LocateProxiesEndpointResponse.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **sync_id** | **str** |  | 
 **path** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/LocateResult.md
+++ b/docs/LocateResult.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **workspace** | **int, none_type** |  | [optional] 
 **workspace_relative_path** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MainApi.md
+++ b/docs/MainApi.md
@@ -166,7 +166,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **beep**
     def beep()
@@ -210,7 +210,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **check_certificate**
     def check_certificate(certificate)
@@ -262,7 +262,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **check_chunk_uploaded**
     def check_chunk_uploaded()
@@ -313,7 +313,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **check_internet_connectivity**
     def CheckConnectivityEndpointResponse check_internet_connectivity()
@@ -359,7 +359,7 @@ This endpoint does not need any parameter.
 
 [**CheckConnectivityEndpointResponse**](CheckConnectivityEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **check_stor_next_license**
     def [StorNextLicenseCheckEndpointResponse] check_stor_next_license(stornext_license)
@@ -412,7 +412,7 @@ Name | Type | Description  | Notes
 
 [**[StorNextLicenseCheckEndpointResponse]**](StorNextLicenseCheckEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **collect_diagnostics**
     def DownloadArchive collect_diagnostics()
@@ -458,7 +458,7 @@ This endpoint does not need any parameter.
 
 [**DownloadArchive**](DownloadArchive.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_archive**
     def DownloadArchive create_archive(create_download_archive)
@@ -521,7 +521,7 @@ Name | Type | Description  | Notes
 
 [**DownloadArchive**](DownloadArchive.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_cloud_account**
     def CloudAccount create_cloud_account(cloud_account_update)
@@ -581,7 +581,7 @@ Name | Type | Description  | Notes
 
 [**CloudAccount**](CloudAccount.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_filesystem_permission**
     def FilesystemPermission create_filesystem_permission(filesystem_permission_update)
@@ -637,7 +637,7 @@ Name | Type | Description  | Notes
 
 [**FilesystemPermission**](FilesystemPermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_group**
     def ElementsGroupDetail create_group(elements_group_detail_update)
@@ -702,7 +702,7 @@ Name | Type | Description  | Notes
 
 [**ElementsGroupDetail**](ElementsGroupDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_home_workspace**
     def Workspace create_home_workspace(id, create_home_workspace_request)
@@ -757,7 +757,7 @@ Name | Type | Description  | Notes
 
 [**Workspace**](Workspace.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_ntp_server**
     def NTPServer create_ntp_server(ntp_server_update)
@@ -811,7 +811,7 @@ Name | Type | Description  | Notes
 
 [**NTPServer**](NTPServer.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_user**
     def ElementsUserDetail create_user(elements_user_detail_update)
@@ -896,7 +896,7 @@ Name | Type | Description  | Notes
 
 [**ElementsUserDetail**](ElementsUserDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_workstation**
     def Workstation create_workstation(workstation_update)
@@ -967,7 +967,7 @@ Name | Type | Description  | Notes
 
 [**Workstation**](Workstation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_cloud_account**
     def delete_cloud_account(id)
@@ -1015,7 +1015,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_download_archive**
     def delete_download_archive(id)
@@ -1063,7 +1063,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_filesystem_permission**
     def delete_filesystem_permission(id)
@@ -1111,7 +1111,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_group**
     def delete_group(id)
@@ -1159,7 +1159,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_home_workspace**
     def delete_home_workspace(id)
@@ -1207,7 +1207,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_ntp_server**
     def delete_ntp_server(id)
@@ -1255,7 +1255,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_user**
     def delete_user(id)
@@ -1303,7 +1303,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_workstation**
     def delete_workstation(id)
@@ -1351,7 +1351,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **disable_user_totp**
     def disable_user_totp(id)
@@ -1397,7 +1397,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **enable_user_totp**
     def enable_user_totp(id, enable_totp_request)
@@ -1449,7 +1449,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **finish_upload**
     def finish_upload(finish_upload_endpoint_request)
@@ -1500,7 +1500,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **fix_ldap_group_memberships**
     def fix_ldap_group_memberships(id)
@@ -1548,7 +1548,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_client_sessions**
     def [ClientSession] get_all_client_sessions()
@@ -1609,7 +1609,7 @@ Name | Type | Description  | Notes
 
 [**[ClientSession]**](ClientSession.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_cloud_accounts**
     def [CloudAccount] get_all_cloud_accounts()
@@ -1668,7 +1668,7 @@ Name | Type | Description  | Notes
 
 [**[CloudAccount]**](CloudAccount.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_download_archives**
     def [DownloadArchive] get_all_download_archives()
@@ -1723,7 +1723,7 @@ Name | Type | Description  | Notes
 
 [**[DownloadArchive]**](DownloadArchive.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_downloads**
     def [Download] get_all_downloads()
@@ -1780,7 +1780,7 @@ Name | Type | Description  | Notes
 
 [**[Download]**](Download.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_filesystem_permissions**
     def [FilesystemPermission] get_all_filesystem_permissions()
@@ -1841,7 +1841,7 @@ Name | Type | Description  | Notes
 
 [**[FilesystemPermission]**](FilesystemPermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_groups**
     def [ElementsGroup] get_all_groups()
@@ -1898,7 +1898,7 @@ Name | Type | Description  | Notes
 
 [**[ElementsGroup]**](ElementsGroup.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_ldap_servers**
     def [LDAPServer] get_all_ldap_servers()
@@ -1953,7 +1953,7 @@ Name | Type | Description  | Notes
 
 [**[LDAPServer]**](LDAPServer.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_ntp_servers**
     def [NTPServer] get_all_ntp_servers()
@@ -2010,7 +2010,7 @@ Name | Type | Description  | Notes
 
 [**[NTPServer]**](NTPServer.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_storage_nodes**
     def [StorageNode] get_all_storage_nodes()
@@ -2075,7 +2075,7 @@ Name | Type | Description  | Notes
 
 [**[StorageNode]**](StorageNode.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_users**
     def [ElementsUser] get_all_users()
@@ -2138,7 +2138,7 @@ Name | Type | Description  | Notes
 
 [**[ElementsUser]**](ElementsUser.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_workstations**
     def [Workstation] get_all_workstations()
@@ -2197,7 +2197,7 @@ Name | Type | Description  | Notes
 
 [**[Workstation]**](Workstation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_certificate_configuration**
     def Certificate get_certificate_configuration()
@@ -2243,7 +2243,7 @@ This endpoint does not need any parameter.
 
 [**Certificate**](Certificate.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_client_download_file**
     def get_client_download_file(file)
@@ -2291,7 +2291,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_client_downloads**
     def [ClientsEndpointResponse] get_client_downloads()
@@ -2337,7 +2337,7 @@ This endpoint does not need any parameter.
 
 [**[ClientsEndpointResponse]**](ClientsEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_client_session**
     def ClientSession get_client_session(id)
@@ -2387,7 +2387,7 @@ Name | Type | Description  | Notes
 
 [**ClientSession**](ClientSession.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_cloud_account**
     def CloudAccount get_cloud_account(id)
@@ -2437,7 +2437,7 @@ Name | Type | Description  | Notes
 
 [**CloudAccount**](CloudAccount.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_cloud_account_storage_roots**
     def [StorageRoot] get_cloud_account_storage_roots(id)
@@ -2487,7 +2487,7 @@ Name | Type | Description  | Notes
 
 [**[StorageRoot]**](StorageRoot.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_current_workstation**
     def Workstation get_current_workstation()
@@ -2542,7 +2542,7 @@ Name | Type | Description  | Notes
 
 [**Workstation**](Workstation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_download**
     def Download get_download(id)
@@ -2592,7 +2592,7 @@ Name | Type | Description  | Notes
 
 [**Download**](Download.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_download_archive**
     def DownloadArchive get_download_archive(id)
@@ -2642,7 +2642,7 @@ Name | Type | Description  | Notes
 
 [**DownloadArchive**](DownloadArchive.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_download_archive_file**
     def get_download_archive_file(id)
@@ -2690,7 +2690,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_download_file**
     def get_download_file(id)
@@ -2738,7 +2738,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_download_icon**
     def get_download_icon(id)
@@ -2786,7 +2786,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_filesystem_permission**
     def FilesystemPermission get_filesystem_permission(id)
@@ -2836,7 +2836,7 @@ Name | Type | Description  | Notes
 
 [**FilesystemPermission**](FilesystemPermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_group**
     def ElementsGroupDetail get_group(id)
@@ -2886,7 +2886,7 @@ Name | Type | Description  | Notes
 
 [**ElementsGroupDetail**](ElementsGroupDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_home_workspace**
     def Workspace get_home_workspace(id)
@@ -2936,7 +2936,7 @@ Name | Type | Description  | Notes
 
 [**Workspace**](Workspace.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ipmi_configuration**
     def Ipmi get_ipmi_configuration(id)
@@ -2986,7 +2986,7 @@ Name | Type | Description  | Notes
 
 [**Ipmi**](Ipmi.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ldap_server**
     def LDAPServer get_ldap_server(id)
@@ -3036,7 +3036,7 @@ Name | Type | Description  | Notes
 
 [**LDAPServer**](LDAPServer.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ldap_server_groups**
     def LDAPServerGroups get_ldap_server_groups(id)
@@ -3086,7 +3086,7 @@ Name | Type | Description  | Notes
 
 [**LDAPServerGroups**](LDAPServerGroups.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ldap_server_users**
     def LDAPServerUsers get_ldap_server_users(id)
@@ -3136,7 +3136,7 @@ Name | Type | Description  | Notes
 
 [**LDAPServerUsers**](LDAPServerUsers.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_license**
     def License get_license()
@@ -3182,7 +3182,7 @@ This endpoint does not need any parameter.
 
 [**License**](License.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_local_time**
     def TimeEndpointResponse get_local_time()
@@ -3228,7 +3228,7 @@ This endpoint does not need any parameter.
 
 [**TimeEndpointResponse**](TimeEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_log**
     def get_log(path)
@@ -3285,7 +3285,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_node_ipmi_sensors**
     def Sensors get_node_ipmi_sensors(id)
@@ -3335,7 +3335,7 @@ Name | Type | Description  | Notes
 
 [**Sensors**](Sensors.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_node_stats**
     def Stats get_node_stats(id)
@@ -3385,7 +3385,7 @@ Name | Type | Description  | Notes
 
 [**Stats**](Stats.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_ntp_server**
     def NTPServer get_ntp_server(id)
@@ -3435,7 +3435,7 @@ Name | Type | Description  | Notes
 
 [**NTPServer**](NTPServer.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_parameters**
     def Parameters get_parameters()
@@ -3490,7 +3490,7 @@ Name | Type | Description  | Notes
 
 [**Parameters**](Parameters.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_profile**
     def ElementsUserProfile get_profile()
@@ -3545,7 +3545,7 @@ Name | Type | Description  | Notes
 
 [**ElementsUserProfile**](ElementsUserProfile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_release_notes**
     def [ReleaseNotesEndpointResponse] get_release_notes()
@@ -3591,7 +3591,7 @@ This endpoint does not need any parameter.
 
 [**[ReleaseNotesEndpointResponse]**](ReleaseNotesEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_service_status**
     def ServiceStatus get_service_status(id, service)
@@ -3643,7 +3643,7 @@ Name | Type | Description  | Notes
 
 [**ServiceStatus**](ServiceStatus.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_smtp_configuration**
     def SMTPConfiguration get_smtp_configuration()
@@ -3689,7 +3689,7 @@ This endpoint does not need any parameter.
 
 [**SMTPConfiguration**](SMTPConfiguration.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_stor_next_license**
     def StorNextLicenseEndpointResponse get_stor_next_license()
@@ -3735,7 +3735,7 @@ This endpoint does not need any parameter.
 
 [**StorNextLicenseEndpointResponse**](StorNextLicenseEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_storage_node**
     def StorageNode get_storage_node(id)
@@ -3795,7 +3795,7 @@ Name | Type | Description  | Notes
 
 [**StorageNode**](StorageNode.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_system_info**
     def SystemInfoEndpointResponse get_system_info()
@@ -3841,7 +3841,7 @@ This endpoint does not need any parameter.
 
 [**SystemInfoEndpointResponse**](SystemInfoEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_user**
     def ElementsUserDetail get_user(id)
@@ -3901,7 +3901,7 @@ Name | Type | Description  | Notes
 
 [**ElementsUserDetail**](ElementsUserDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_workstation**
     def Workstation get_workstation(id)
@@ -3951,7 +3951,7 @@ Name | Type | Description  | Notes
 
 [**Workstation**](Workstation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **install_stor_next_license**
     def StorNextLicenseEndpointResponse install_stor_next_license(stornext_license)
@@ -4004,7 +4004,7 @@ Name | Type | Description  | Notes
 
 [**StorNextLicenseEndpointResponse**](StorNextLicenseEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_cloud_account**
     def CloudAccount patch_cloud_account(id, cloud_account_partial_update)
@@ -4066,7 +4066,7 @@ Name | Type | Description  | Notes
 
 [**CloudAccount**](CloudAccount.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_current_workstation**
     def Workstation patch_current_workstation(workstation_partial_update)
@@ -4137,7 +4137,7 @@ Name | Type | Description  | Notes
 
 [**Workstation**](Workstation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_download_archive**
     def DownloadArchive patch_download_archive(id, download_archive_partial_update)
@@ -4273,7 +4273,7 @@ Name | Type | Description  | Notes
 
 [**DownloadArchive**](DownloadArchive.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_filesystem_permission**
     def FilesystemPermission patch_filesystem_permission(id, filesystem_permission_partial_update)
@@ -4331,7 +4331,7 @@ Name | Type | Description  | Notes
 
 [**FilesystemPermission**](FilesystemPermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_group**
     def ElementsGroupDetail patch_group(id, elements_group_detail_partial_update)
@@ -4398,7 +4398,7 @@ Name | Type | Description  | Notes
 
 [**ElementsGroupDetail**](ElementsGroupDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_ntp_server**
     def NTPServer patch_ntp_server(id, ntp_server_partial_update)
@@ -4454,7 +4454,7 @@ Name | Type | Description  | Notes
 
 [**NTPServer**](NTPServer.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_profile**
     def ElementsUserProfile patch_profile(elements_user_profile_partial_update)
@@ -4513,7 +4513,7 @@ Name | Type | Description  | Notes
 
 [**ElementsUserProfile**](ElementsUserProfile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_user**
     def ElementsUserDetail patch_user(id, elements_user_detail_partial_update)
@@ -4600,7 +4600,7 @@ Name | Type | Description  | Notes
 
 [**ElementsUserDetail**](ElementsUserDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_workstation**
     def Workstation patch_workstation(id, workstation_partial_update)
@@ -4673,7 +4673,7 @@ Name | Type | Description  | Notes
 
 [**Workstation**](Workstation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **preview_user**
     def UserPreviewResponse preview_user(user_preview_request)
@@ -4724,7 +4724,7 @@ Name | Type | Description  | Notes
 
 [**UserPreviewResponse**](UserPreviewResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **reboot**
     def reboot()
@@ -4768,7 +4768,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **register_upload**
     def register_upload(register_upload_endpoint_request)
@@ -4820,7 +4820,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **register_upload_metadata**
     def register_upload_metadata(register_upload_metadata_endpoint_request)
@@ -4883,7 +4883,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **render_email_template_preview**
     def render_email_template_preview(email_preview)
@@ -4936,7 +4936,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **reset_user_password**
     def reset_user_password(id)
@@ -4984,7 +4984,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **restart_web_ui**
     def restart_web_ui()
@@ -5028,7 +5028,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **run_service_operation**
     def run_service_operation(id, operation, service)
@@ -5080,7 +5080,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **set_ipmi_configuration**
     def Ipmi set_ipmi_configuration(id, ipmi)
@@ -5136,7 +5136,7 @@ Name | Type | Description  | Notes
 
 [**Ipmi**](Ipmi.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **set_local_time**
     def TimeEndpointResponse set_local_time(time_endpoint_request)
@@ -5192,7 +5192,7 @@ Name | Type | Description  | Notes
 
 [**TimeEndpointResponse**](TimeEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **set_my_password**
     def set_my_password(change_own_password_request)
@@ -5245,7 +5245,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **set_user_password**
     def set_user_password(id, change_password_request)
@@ -5298,7 +5298,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **shutdown**
     def shutdown()
@@ -5342,7 +5342,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **start_solr_reindex**
     def SolrReindexEndpointResponse start_solr_reindex()
@@ -5388,7 +5388,7 @@ This endpoint does not need any parameter.
 
 [**SolrReindexEndpointResponse**](SolrReindexEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **start_support_session**
     def TaskInfo start_support_session()
@@ -5434,7 +5434,7 @@ This endpoint does not need any parameter.
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **start_system_backup**
     def TaskInfo start_system_backup(path)
@@ -5487,7 +5487,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **sync_ldap_group**
     def sync_ldap_group(id)
@@ -5535,7 +5535,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **sync_ldap_users**
     def sync_ldap_users(id)
@@ -5583,7 +5583,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **sync_time**
     def TimeSyncEndpointResponse sync_time(time_sync_endpoint_request)
@@ -5636,7 +5636,7 @@ Name | Type | Description  | Notes
 
 [**TimeSyncEndpointResponse**](TimeSyncEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **sync_user_totp**
     def SyncTOTP sync_user_totp(id, sync_totp_request)
@@ -5689,7 +5689,7 @@ Name | Type | Description  | Notes
 
 [**SyncTOTP**](SyncTOTP.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **test_cloud_account_credentials**
     def TestCloudAccountCredentialsResponse test_cloud_account_credentials(test_cloud_account_credentials_request)
@@ -5749,7 +5749,7 @@ Name | Type | Description  | Notes
 
 [**TestCloudAccountCredentialsResponse**](TestCloudAccountCredentialsResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **test_smtp_configuration**
     def test_smtp_configuration(test_smtp)
@@ -5800,7 +5800,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_certificate_configuration**
     def Certificate update_certificate_configuration(certificate_update)
@@ -5854,7 +5854,7 @@ Name | Type | Description  | Notes
 
 [**Certificate**](Certificate.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_cloud_account**
     def CloudAccount update_cloud_account(id, cloud_account_update)
@@ -5916,7 +5916,7 @@ Name | Type | Description  | Notes
 
 [**CloudAccount**](CloudAccount.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_current_workstation**
     def Workstation update_current_workstation(workstation_update)
@@ -5987,7 +5987,7 @@ Name | Type | Description  | Notes
 
 [**Workstation**](Workstation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_download_archive**
     def DownloadArchive update_download_archive(id, download_archive_update)
@@ -6123,7 +6123,7 @@ Name | Type | Description  | Notes
 
 [**DownloadArchive**](DownloadArchive.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_filesystem_permission**
     def FilesystemPermission update_filesystem_permission(id, filesystem_permission_update)
@@ -6181,7 +6181,7 @@ Name | Type | Description  | Notes
 
 [**FilesystemPermission**](FilesystemPermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_group**
     def ElementsGroupDetail update_group(id, elements_group_detail_update)
@@ -6248,7 +6248,7 @@ Name | Type | Description  | Notes
 
 [**ElementsGroupDetail**](ElementsGroupDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_ntp_server**
     def NTPServer update_ntp_server(id, ntp_server_update)
@@ -6304,7 +6304,7 @@ Name | Type | Description  | Notes
 
 [**NTPServer**](NTPServer.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_parameters**
     def Parameters update_parameters(parameters_update)
@@ -6386,7 +6386,7 @@ Name | Type | Description  | Notes
 
 [**Parameters**](Parameters.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_profile**
     def ElementsUserProfile update_profile(elements_user_profile_update)
@@ -6445,7 +6445,7 @@ Name | Type | Description  | Notes
 
 [**ElementsUserProfile**](ElementsUserProfile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_smtp_configuration**
     def SMTPConfiguration update_smtp_configuration(smtp_configuration_update)
@@ -6503,7 +6503,7 @@ Name | Type | Description  | Notes
 
 [**SMTPConfiguration**](SMTPConfiguration.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_user**
     def ElementsUserDetail update_user(id, elements_user_detail_update)
@@ -6590,7 +6590,7 @@ Name | Type | Description  | Notes
 
 [**ElementsUserDetail**](ElementsUserDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_workstation**
     def Workstation update_workstation(id, workstation_update)
@@ -6663,7 +6663,7 @@ Name | Type | Description  | Notes
 
 [**Workstation**](Workstation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **upload_chunk**
     def upload_chunk(upload_chunk_endpoint_request)
@@ -6716,5 +6716,5 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/Marker.md
+++ b/docs/Marker.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **title** | **str** |  | [optional] 
 **text** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MarkerPartialUpdate.md
+++ b/docs/MarkerPartialUpdate.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **t_out** | **float** |  | [optional] 
 **asset** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MarkerUpdate.md
+++ b/docs/MarkerUpdate.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **title** | **str** |  | [optional] 
 **text** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaFile.md
+++ b/docs/MediaFile.md
@@ -37,6 +37,6 @@ Name | Type | Description | Notes
 **needs_rescan** | **bool** |  | [optional] 
 **bookmarked_by** | **[int]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaFileBundle.md
+++ b/docs/MediaFileBundle.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **asset** | [**Asset**](Asset.md) |  | [optional] 
 **shared_via_tokens** | **[int]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaFileBundleMini.md
+++ b/docs/MediaFileBundleMini.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **location** | **int** |  | 
 **mainfile** | [**MediaFileMini**](MediaFileMini.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaFileBundleMiniReference.md
+++ b/docs/MediaFileBundleMiniReference.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **location** | **int** |  | [optional] [readonly] 
 **mainfile** | [**MediaFileMini**](MediaFileMini.md) |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaFileContents.md
+++ b/docs/MediaFileContents.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **bundles** | [**[MediaFileBundle]**](MediaFileBundle.md) |  | [readonly] 
 **total** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaFileMini.md
+++ b/docs/MediaFileMini.md
@@ -20,6 +20,6 @@ Name | Type | Description | Notes
 **custom_fields** | **{str: (str, none_type)}** |  | [optional] 
 **parent_file** | **{str: (str, none_type)}** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaFilePartialUpdate.md
+++ b/docs/MediaFilePartialUpdate.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **needs_rescan** | **bool** |  | [optional] 
 **bookmarked_by** | **[int]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaFileReference.md
+++ b/docs/MediaFileReference.md
@@ -37,6 +37,6 @@ Name | Type | Description | Notes
 **bundle** | **int** |  | [optional] [readonly] 
 **bookmarked_by** | **[int]** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaFileTemplate.md
+++ b/docs/MediaFileTemplate.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **file** | [**MediaFileReference**](MediaFileReference.md) |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaFileTemplatePartialUpdate.md
+++ b/docs/MediaFileTemplatePartialUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **file** | [**MediaFileReference**](MediaFileReference.md) |  | [optional] 
 **name** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaFileTemplateUpdate.md
+++ b/docs/MediaFileTemplateUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **file** | [**MediaFileReference**](MediaFileReference.md) |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaFileUpdate.md
+++ b/docs/MediaFileUpdate.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **needs_rescan** | **bool** |  | [optional] 
 **bookmarked_by** | **[int]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaFilesLookupRequest.md
+++ b/docs/MediaFilesLookupRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **query** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaLibraryApi.md
+++ b/docs/MediaLibraryApi.md
@@ -222,7 +222,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **clear_subclip_clipboard**
     def clear_subclip_clipboard()
@@ -266,7 +266,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **clear_subtitle_clipboard**
     def clear_subtitle_clipboard()
@@ -310,7 +310,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **combine_assets_into_set**
     def combine_assets_into_set(multiple_assets_request)
@@ -363,7 +363,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_asset**
     def Asset create_asset(asset_update)
@@ -422,7 +422,7 @@ Name | Type | Description  | Notes
 
 [**Asset**](Asset.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_asset_rating**
     def AssetRating create_asset_rating(asset_rating_update)
@@ -489,7 +489,7 @@ Name | Type | Description  | Notes
 
 [**AssetRating**](AssetRating.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_asset_subtitle_link**
     def AssetSubtitleLink create_asset_subtitle_link(asset_subtitle_link_update)
@@ -562,7 +562,7 @@ Name | Type | Description  | Notes
 
 [**AssetSubtitleLink**](AssetSubtitleLink.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_comment**
     def Comment create_comment(comment_update)
@@ -644,7 +644,7 @@ Name | Type | Description  | Notes
 
 [**Comment**](Comment.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_custom_field**
     def CustomField create_custom_field(custom_field_update)
@@ -719,7 +719,7 @@ Name | Type | Description  | Notes
 
 [**CustomField**](CustomField.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_editor_project**
     def EditorProject create_editor_project(editor_project_update)
@@ -777,7 +777,7 @@ Name | Type | Description  | Notes
 
 [**EditorProject**](EditorProject.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_editor_subtitle**
     def EditorSubtitle create_editor_subtitle(editor_subtitle_update)
@@ -857,7 +857,7 @@ Name | Type | Description  | Notes
 
 [**EditorSubtitle**](EditorSubtitle.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_external_transcoder**
     def ExternalTranscoder create_external_transcoder(external_transcoder_update)
@@ -917,7 +917,7 @@ Name | Type | Description  | Notes
 
 [**ExternalTranscoder**](ExternalTranscoder.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_marker**
     def Marker create_marker(marker_update)
@@ -974,7 +974,7 @@ Name | Type | Description  | Notes
 
 [**Marker**](Marker.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_media_file_template**
     def MediaFileTemplate create_media_file_template(media_file_template_update)
@@ -1088,7 +1088,7 @@ Name | Type | Description  | Notes
 
 [**MediaFileTemplate**](MediaFileTemplate.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_media_root**
     def MediaRootDetail create_media_root(media_root_detail_update)
@@ -1195,7 +1195,7 @@ Name | Type | Description  | Notes
 
 [**MediaRootDetail**](MediaRootDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_media_root_permission**
     def MediaRootPermission create_media_root_permission(media_root_permission_update)
@@ -1272,7 +1272,7 @@ Name | Type | Description  | Notes
 
 [**MediaRootPermission**](MediaRootPermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_media_tag**
     def UnfilteredTag create_media_tag(unfiltered_tag_update)
@@ -1330,7 +1330,7 @@ Name | Type | Description  | Notes
 
 [**UnfilteredTag**](UnfilteredTag.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_proxy_profile**
     def ProxyProfile create_proxy_profile(proxy_profile_update)
@@ -1408,7 +1408,7 @@ Name | Type | Description  | Notes
 
 [**ProxyProfile**](ProxyProfile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_saved_search**
     def SavedSearch create_saved_search(saved_search_update)
@@ -1466,7 +1466,7 @@ Name | Type | Description  | Notes
 
 [**SavedSearch**](SavedSearch.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_subclip**
     def Subclip create_subclip(subclip_update)
@@ -1548,7 +1548,7 @@ Name | Type | Description  | Notes
 
 [**Subclip**](Subclip.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_subclip_clipboard_entry**
     def SubclipClipboardEntry create_subclip_clipboard_entry(subclip_clipboard_entry_update)
@@ -1630,7 +1630,7 @@ Name | Type | Description  | Notes
 
 [**SubclipClipboardEntry**](SubclipClipboardEntry.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_subtitle_clipboard_entry**
     def SubtitleClipboardEntry create_subtitle_clipboard_entry(subtitle_clipboard_entry_update)
@@ -1701,7 +1701,7 @@ Name | Type | Description  | Notes
 
 [**SubtitleClipboardEntry**](SubtitleClipboardEntry.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_asset**
     def delete_asset(id)
@@ -1749,7 +1749,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_asset_rating**
     def delete_asset_rating(id)
@@ -1806,7 +1806,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_asset_subtitle_link**
     def delete_asset_subtitle_link(id)
@@ -1854,7 +1854,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_comment**
     def delete_comment(id)
@@ -1902,7 +1902,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_custom_field**
     def delete_custom_field(id)
@@ -1950,7 +1950,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_easy_sharing_token_for_bundle**
     def delete_easy_sharing_token_for_bundle(id)
@@ -1998,7 +1998,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_easy_sharing_token_for_directory**
     def delete_easy_sharing_token_for_directory(id)
@@ -2046,7 +2046,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_external_transcoder**
     def delete_external_transcoder(id)
@@ -2094,7 +2094,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_marker**
     def delete_marker(id)
@@ -2142,7 +2142,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_media_file_template**
     def delete_media_file_template(id)
@@ -2190,7 +2190,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_media_library_objects**
     def [TaskInfo] delete_media_library_objects(media_library_delete_request)
@@ -2253,7 +2253,7 @@ Name | Type | Description  | Notes
 
 [**[TaskInfo]**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_media_root**
     def delete_media_root(id)
@@ -2301,7 +2301,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_media_root_permission**
     def delete_media_root_permission(id)
@@ -2349,7 +2349,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_media_tag**
     def delete_media_tag(id)
@@ -2397,7 +2397,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_media_update**
     def delete_media_update(id)
@@ -2445,7 +2445,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_proxy**
     def delete_proxy(id)
@@ -2493,7 +2493,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_proxy_profile**
     def delete_proxy_profile(id)
@@ -2541,7 +2541,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_saved_search**
     def delete_saved_search(id)
@@ -2589,7 +2589,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_subclip**
     def delete_subclip(id)
@@ -2637,7 +2637,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_subclip_clipboard_entry**
     def delete_subclip_clipboard_entry(id)
@@ -2685,7 +2685,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_subtitle_clipboard_entry**
     def delete_subtitle_clipboard_entry(id)
@@ -2733,7 +2733,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **discover_media**
     def MediaFile discover_media(scanner_discover_endpoint_request)
@@ -2787,7 +2787,7 @@ Name | Type | Description  | Notes
 
 [**MediaFile**](MediaFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **download_asset_proxy_file**
     def download_asset_proxy_file(filename, id)
@@ -2837,7 +2837,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **download_media_file**
     def download_media_file(id)
@@ -2885,7 +2885,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **download_proxy**
     def download_proxy(id)
@@ -2933,7 +2933,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **editor_export_xml_for_assset**
     def editor_export_xml_for_assset(asset_ids)
@@ -2994,7 +2994,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **editor_export_xml_for_bundle**
     def editor_export_xml_for_bundle(bundle_ids)
@@ -3055,7 +3055,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **editor_export_xml_for_project**
     def editor_export_xml_for_project(id)
@@ -3103,7 +3103,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **export_comments_for_avid**
     def export_comments_for_avid(asset_id, export_format)
@@ -3166,7 +3166,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **export_editor_timeline**
     def export_editor_timeline(timeline_export_request)
@@ -3219,7 +3219,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **extract_stream**
     def TaskInfo extract_stream(id, extract_request)
@@ -3275,7 +3275,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **forget_deleted_media_files**
     def forget_deleted_media_files(id)
@@ -3323,7 +3323,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **generate_proxies**
     def [TaskInfo] generate_proxies(generate_proxies_request)
@@ -3386,7 +3386,7 @@ Name | Type | Description  | Notes
 
 [**[TaskInfo]**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_asset_project_links**
     def [AssetProjectLink] get_all_asset_project_links()
@@ -3445,7 +3445,7 @@ Name | Type | Description  | Notes
 
 [**[AssetProjectLink]**](AssetProjectLink.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_asset_ratings**
     def [AssetRating] get_all_asset_ratings()
@@ -3504,7 +3504,7 @@ Name | Type | Description  | Notes
 
 [**[AssetRating]**](AssetRating.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_asset_subtitle_links**
     def [AssetSubtitleLink] get_all_asset_subtitle_links()
@@ -3563,7 +3563,7 @@ Name | Type | Description  | Notes
 
 [**[AssetSubtitleLink]**](AssetSubtitleLink.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_asset_tape_backups**
     def [AssetBackup] get_all_asset_tape_backups()
@@ -3624,7 +3624,7 @@ Name | Type | Description  | Notes
 
 [**[AssetBackup]**](AssetBackup.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_assets**
     def [Asset] get_all_assets()
@@ -3693,7 +3693,7 @@ Name | Type | Description  | Notes
 
 [**[Asset]**](Asset.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_bundles_for_media_root**
     def [MediaFileBundle] get_all_bundles_for_media_root(root)
@@ -3767,7 +3767,7 @@ Name | Type | Description  | Notes
 
 [**[MediaFileBundle]**](MediaFileBundle.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_bundles_in_subtree**
     def [MediaFileBundle] get_all_bundles_in_subtree(file)
@@ -3841,7 +3841,7 @@ Name | Type | Description  | Notes
 
 [**[MediaFileBundle]**](MediaFileBundle.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_click_links**
     def [AssetCloudLink] get_all_click_links()
@@ -3900,7 +3900,7 @@ Name | Type | Description  | Notes
 
 [**[AssetCloudLink]**](AssetCloudLink.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_comments**
     def [Comment] get_all_comments()
@@ -3969,7 +3969,7 @@ Name | Type | Description  | Notes
 
 [**[Comment]**](Comment.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_custom_fields**
     def [CustomField] get_all_custom_fields()
@@ -4024,7 +4024,7 @@ Name | Type | Description  | Notes
 
 [**[CustomField]**](CustomField.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_external_transcoders**
     def [ExternalTranscoder] get_all_external_transcoders()
@@ -4083,7 +4083,7 @@ Name | Type | Description  | Notes
 
 [**[ExternalTranscoder]**](ExternalTranscoder.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_markers**
     def [Marker] get_all_markers()
@@ -4142,7 +4142,7 @@ Name | Type | Description  | Notes
 
 [**[Marker]**](Marker.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_media_file_bundles**
     def [MediaFileBundle] get_all_media_file_bundles()
@@ -4217,7 +4217,7 @@ Name | Type | Description  | Notes
 
 [**[MediaFileBundle]**](MediaFileBundle.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_media_file_templates**
     def [MediaFileTemplate] get_all_media_file_templates()
@@ -4272,7 +4272,7 @@ Name | Type | Description  | Notes
 
 [**[MediaFileTemplate]**](MediaFileTemplate.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_media_files**
     def [MediaFile] get_all_media_files()
@@ -4361,7 +4361,7 @@ Name | Type | Description  | Notes
 
 [**[MediaFile]**](MediaFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_media_files_for_bundles**
     def [MediaFile] get_all_media_files_for_bundles(all_media_files_for_bundles_request)
@@ -4416,7 +4416,7 @@ Name | Type | Description  | Notes
 
 [**[MediaFile]**](MediaFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_media_files_for_media_root**
     def [MediaFile] get_all_media_files_for_media_root(root)
@@ -4502,7 +4502,7 @@ Name | Type | Description  | Notes
 
 [**[MediaFile]**](MediaFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_media_files_in_subtree**
     def [MediaFile] get_all_media_files_in_subtree(file)
@@ -4588,7 +4588,7 @@ Name | Type | Description  | Notes
 
 [**[MediaFile]**](MediaFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_media_root_permissions**
     def [MediaRootPermission] get_all_media_root_permissions()
@@ -4647,7 +4647,7 @@ Name | Type | Description  | Notes
 
 [**[MediaRootPermission]**](MediaRootPermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_media_roots**
     def [MediaRoot] get_all_media_roots()
@@ -4710,7 +4710,7 @@ Name | Type | Description  | Notes
 
 [**[MediaRoot]**](MediaRoot.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_media_tags**
     def [UnfilteredTag] get_all_media_tags()
@@ -4777,7 +4777,7 @@ Name | Type | Description  | Notes
 
 [**[UnfilteredTag]**](UnfilteredTag.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_media_updates**
     def [MediaUpdate] get_all_media_updates()
@@ -4838,7 +4838,7 @@ Name | Type | Description  | Notes
 
 [**[MediaUpdate]**](MediaUpdate.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_proxy_generators**
     def [ProxyGenerator] get_all_proxy_generators()
@@ -4893,7 +4893,7 @@ Name | Type | Description  | Notes
 
 [**[ProxyGenerator]**](ProxyGenerator.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_proxy_profiles**
     def [ProxyProfile] get_all_proxy_profiles()
@@ -4952,7 +4952,7 @@ Name | Type | Description  | Notes
 
 [**[ProxyProfile]**](ProxyProfile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_saved_searches**
     def [SavedSearch] get_all_saved_searches()
@@ -5015,7 +5015,7 @@ Name | Type | Description  | Notes
 
 [**[SavedSearch]**](SavedSearch.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_subclip_clipboard_entries**
     def [SubclipClipboardEntry] get_all_subclip_clipboard_entries()
@@ -5072,7 +5072,7 @@ Name | Type | Description  | Notes
 
 [**[SubclipClipboardEntry]**](SubclipClipboardEntry.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_subclips**
     def [Subclip] get_all_subclips()
@@ -5135,7 +5135,7 @@ Name | Type | Description  | Notes
 
 [**[Subclip]**](Subclip.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_subtitle_clipboard_entries**
     def [SubtitleClipboardEntry] get_all_subtitle_clipboard_entries()
@@ -5192,7 +5192,7 @@ Name | Type | Description  | Notes
 
 [**[SubtitleClipboardEntry]**](SubtitleClipboardEntry.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_transcoder_profiles**
     def [TranscoderProfile] get_all_transcoder_profiles()
@@ -5247,7 +5247,7 @@ Name | Type | Description  | Notes
 
 [**[TranscoderProfile]**](TranscoderProfile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_asset**
     def Asset get_asset(id)
@@ -5313,7 +5313,7 @@ Name | Type | Description  | Notes
 
 [**Asset**](Asset.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_asset_rating**
     def AssetRating get_asset_rating(id)
@@ -5363,7 +5363,7 @@ Name | Type | Description  | Notes
 
 [**AssetRating**](AssetRating.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_asset_subtitle_link**
     def AssetSubtitleLink get_asset_subtitle_link(id)
@@ -5413,7 +5413,7 @@ Name | Type | Description  | Notes
 
 [**AssetSubtitleLink**](AssetSubtitleLink.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_bookmarked_media_files_directories**
     def [MediaFile] get_bookmarked_media_files_directories()
@@ -5490,7 +5490,7 @@ Name | Type | Description  | Notes
 
 [**[MediaFile]**](MediaFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_comment**
     def Comment get_comment(id)
@@ -5556,7 +5556,7 @@ Name | Type | Description  | Notes
 
 [**Comment**](Comment.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_custom_field**
     def CustomField get_custom_field(id)
@@ -5606,7 +5606,7 @@ Name | Type | Description  | Notes
 
 [**CustomField**](CustomField.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_easy_sharing_token_for_bundle**
     def OneTimeAccessToken get_easy_sharing_token_for_bundle(id)
@@ -5656,7 +5656,7 @@ Name | Type | Description  | Notes
 
 [**OneTimeAccessToken**](OneTimeAccessToken.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_easy_sharing_token_for_directory**
     def OneTimeAccessToken get_easy_sharing_token_for_directory(id)
@@ -5706,7 +5706,7 @@ Name | Type | Description  | Notes
 
 [**OneTimeAccessToken**](OneTimeAccessToken.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_editor_project**
     def EditorProject get_editor_project(id)
@@ -5756,7 +5756,7 @@ Name | Type | Description  | Notes
 
 [**EditorProject**](EditorProject.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_editor_subtitle**
     def EditorSubtitle get_editor_subtitle(id)
@@ -5806,7 +5806,7 @@ Name | Type | Description  | Notes
 
 [**EditorSubtitle**](EditorSubtitle.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_external_transcoder**
     def ExternalTranscoder get_external_transcoder(id)
@@ -5856,7 +5856,7 @@ Name | Type | Description  | Notes
 
 [**ExternalTranscoder**](ExternalTranscoder.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_frame**
     def file_type get_frame(frame, id)
@@ -5907,7 +5907,7 @@ Name | Type | Description  | Notes
 
 **file_type**
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_latest_media_update**
     def MediaUpdate get_latest_media_update()
@@ -5968,7 +5968,7 @@ Name | Type | Description  | Notes
 
 [**MediaUpdate**](MediaUpdate.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_marker**
     def Marker get_marker(id)
@@ -6018,7 +6018,7 @@ Name | Type | Description  | Notes
 
 [**Marker**](Marker.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_media_file**
     def MediaFile get_media_file(id)
@@ -6088,7 +6088,7 @@ Name | Type | Description  | Notes
 
 [**MediaFile**](MediaFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_media_file_bundle**
     def MediaFileBundle get_media_file_bundle(id)
@@ -6160,7 +6160,7 @@ Name | Type | Description  | Notes
 
 [**MediaFileBundle**](MediaFileBundle.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_media_file_contents**
     def MediaFileContents get_media_file_contents(id)
@@ -6226,7 +6226,7 @@ Name | Type | Description  | Notes
 
 [**MediaFileContents**](MediaFileContents.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_media_file_template**
     def MediaFileTemplate get_media_file_template(id)
@@ -6276,7 +6276,7 @@ Name | Type | Description  | Notes
 
 [**MediaFileTemplate**](MediaFileTemplate.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_media_root**
     def MediaRootDetail get_media_root(id)
@@ -6336,7 +6336,7 @@ Name | Type | Description  | Notes
 
 [**MediaRootDetail**](MediaRootDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_media_root_permission**
     def MediaRootPermission get_media_root_permission(id)
@@ -6386,7 +6386,7 @@ Name | Type | Description  | Notes
 
 [**MediaRootPermission**](MediaRootPermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_media_tag**
     def UnfilteredTag get_media_tag(id)
@@ -6446,7 +6446,7 @@ Name | Type | Description  | Notes
 
 [**UnfilteredTag**](UnfilteredTag.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_multiple_assets**
     def [Asset] get_multiple_assets(multiple_assets_request)
@@ -6501,7 +6501,7 @@ Name | Type | Description  | Notes
 
 [**[Asset]**](Asset.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_multiple_bundles**
     def [MediaFileBundle] get_multiple_bundles(get_multiple_bundles_request)
@@ -6559,7 +6559,7 @@ Name | Type | Description  | Notes
 
 [**[MediaFileBundle]**](MediaFileBundle.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_multiple_files**
     def [MediaFile] get_multiple_files(get_multiple_files_request)
@@ -6614,7 +6614,7 @@ Name | Type | Description  | Notes
 
 [**[MediaFile]**](MediaFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_my_media_root_permissions**
     def [MediaRootPermission] get_my_media_root_permissions()
@@ -6673,7 +6673,7 @@ Name | Type | Description  | Notes
 
 [**[MediaRootPermission]**](MediaRootPermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_my_resolved_media_root_permissions**
     def [MediaRootPermission] get_my_resolved_media_root_permissions()
@@ -6732,7 +6732,7 @@ Name | Type | Description  | Notes
 
 [**[MediaRootPermission]**](MediaRootPermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_proxy**
     def Proxy get_proxy(id)
@@ -6782,7 +6782,7 @@ Name | Type | Description  | Notes
 
 [**Proxy**](Proxy.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_proxy_generator**
     def ProxyGenerator get_proxy_generator(id)
@@ -6832,7 +6832,7 @@ Name | Type | Description  | Notes
 
 [**ProxyGenerator**](ProxyGenerator.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_proxy_profile**
     def ProxyProfile get_proxy_profile(id)
@@ -6892,7 +6892,7 @@ Name | Type | Description  | Notes
 
 [**ProxyProfile**](ProxyProfile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_proxy_profile_proxy_count**
     def ProxyCount get_proxy_profile_proxy_count(id)
@@ -6942,7 +6942,7 @@ Name | Type | Description  | Notes
 
 [**ProxyCount**](ProxyCount.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_saved_search**
     def SavedSearch get_saved_search(id)
@@ -6992,7 +6992,7 @@ Name | Type | Description  | Notes
 
 [**SavedSearch**](SavedSearch.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_subclip**
     def Subclip get_subclip(id)
@@ -7042,7 +7042,7 @@ Name | Type | Description  | Notes
 
 [**Subclip**](Subclip.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_subtitles**
     def file_type get_subtitles(id, title)
@@ -7093,7 +7093,7 @@ Name | Type | Description  | Notes
 
 **file_type**
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_transcoder_profile**
     def TranscoderProfile get_transcoder_profile(id)
@@ -7143,7 +7143,7 @@ Name | Type | Description  | Notes
 
 [**TranscoderProfile**](TranscoderProfile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_vantage_workflows**
     def VantageWorkflows get_vantage_workflows(id)
@@ -7193,7 +7193,7 @@ Name | Type | Description  | Notes
 
 [**VantageWorkflows**](VantageWorkflows.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **instantiate_media_file_template**
     def instantiate_media_file_template(id, instantiate_file_template_request)
@@ -7250,7 +7250,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **locate_editor_project_paths**
     def [LocateResult] locate_editor_project_paths(id)
@@ -7300,7 +7300,7 @@ Name | Type | Description  | Notes
 
 [**[LocateResult]**](LocateResult.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **lookup_media_files**
     def [MediaFile] lookup_media_files(media_files_lookup_request)
@@ -7353,7 +7353,7 @@ Name | Type | Description  | Notes
 
 [**[MediaFile]**](MediaFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **mark_media_directory_as_showroom**
     def mark_media_directory_as_showroom(id)
@@ -7401,7 +7401,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_asset**
     def Asset patch_asset(id, asset_partial_update)
@@ -7472,7 +7472,7 @@ Name | Type | Description  | Notes
 
 [**Asset**](Asset.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_asset_rating**
     def AssetRating patch_asset_rating(id, asset_rating_partial_update)
@@ -7531,7 +7531,7 @@ Name | Type | Description  | Notes
 
 [**AssetRating**](AssetRating.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_asset_subtitle_link**
     def AssetSubtitleLink patch_asset_subtitle_link(id, asset_subtitle_link_partial_update)
@@ -7606,7 +7606,7 @@ Name | Type | Description  | Notes
 
 [**AssetSubtitleLink**](AssetSubtitleLink.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_comment**
     def Comment patch_comment(id, comment_partial_update)
@@ -7678,7 +7678,7 @@ Name | Type | Description  | Notes
 
 [**Comment**](Comment.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_custom_field**
     def CustomField patch_custom_field(id, custom_field_partial_update)
@@ -7755,7 +7755,7 @@ Name | Type | Description  | Notes
 
 [**CustomField**](CustomField.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_editor_project**
     def EditorProject patch_editor_project(id, editor_project_partial_update)
@@ -7815,7 +7815,7 @@ Name | Type | Description  | Notes
 
 [**EditorProject**](EditorProject.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_editor_subtitle**
     def EditorSubtitle patch_editor_subtitle(id, editor_subtitle_partial_update)
@@ -7897,7 +7897,7 @@ Name | Type | Description  | Notes
 
 [**EditorSubtitle**](EditorSubtitle.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_external_transcoder**
     def ExternalTranscoder patch_external_transcoder(id, external_transcoder_partial_update)
@@ -7959,7 +7959,7 @@ Name | Type | Description  | Notes
 
 [**ExternalTranscoder**](ExternalTranscoder.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_marker**
     def Marker patch_marker(id, marker_partial_update)
@@ -8018,7 +8018,7 @@ Name | Type | Description  | Notes
 
 [**Marker**](Marker.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_media_file**
     def MediaFile patch_media_file(id, media_file_partial_update)
@@ -8093,7 +8093,7 @@ Name | Type | Description  | Notes
 
 [**MediaFile**](MediaFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_media_file_template**
     def MediaFileTemplate patch_media_file_template(id, media_file_template_partial_update)
@@ -8209,7 +8209,7 @@ Name | Type | Description  | Notes
 
 [**MediaFileTemplate**](MediaFileTemplate.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_media_root**
     def MediaRootDetail patch_media_root(id, media_root_detail_partial_update)
@@ -8317,7 +8317,7 @@ Name | Type | Description  | Notes
 
 [**MediaRootDetail**](MediaRootDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_media_root_permission**
     def MediaRootPermission patch_media_root_permission(id, media_root_permission_partial_update)
@@ -8396,7 +8396,7 @@ Name | Type | Description  | Notes
 
 [**MediaRootPermission**](MediaRootPermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_media_tag**
     def UnfilteredTag patch_media_tag(id, unfiltered_tag_partial_update)
@@ -8456,7 +8456,7 @@ Name | Type | Description  | Notes
 
 [**UnfilteredTag**](UnfilteredTag.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_proxy_profile**
     def ProxyProfile patch_proxy_profile(id, proxy_profile_partial_update)
@@ -8536,7 +8536,7 @@ Name | Type | Description  | Notes
 
 [**ProxyProfile**](ProxyProfile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_saved_search**
     def SavedSearch patch_saved_search(id, saved_search_partial_update)
@@ -8596,7 +8596,7 @@ Name | Type | Description  | Notes
 
 [**SavedSearch**](SavedSearch.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_subclip**
     def Subclip patch_subclip(id, subclip_partial_update)
@@ -8680,7 +8680,7 @@ Name | Type | Description  | Notes
 
 [**Subclip**](Subclip.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **recursively_tag_media_directory**
     def recursively_tag_media_directory(id, tag_media_directory_request)
@@ -8734,7 +8734,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **reindex_media_directory**
     def reindex_media_directory(id)
@@ -8782,7 +8782,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **rename_custom_field**
     def TaskInfo rename_custom_field(id, rename_custom_field_request)
@@ -8837,7 +8837,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **render_sequence**
     def TaskInfo render_sequence(render_endpoint_request)
@@ -8892,7 +8892,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **render_subclip**
     def TaskInfo render_subclip(id, render_request)
@@ -8947,7 +8947,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **request_media_scan**
     def request_media_scan(scanner_scan_endpoint_request)
@@ -9001,7 +9001,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **resolve_comment**
     def Comment resolve_comment(id)
@@ -9051,7 +9051,7 @@ Name | Type | Description  | Notes
 
 [**Comment**](Comment.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **share_media_library_objects**
     def OneTimeAccessToken share_media_library_objects(media_library_share_request)
@@ -9137,7 +9137,7 @@ Name | Type | Description  | Notes
 
 [**OneTimeAccessToken**](OneTimeAccessToken.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **test_external_transcoder_connection**
     def TestExternalTranscoderConnectionResponse test_external_transcoder_connection(test_external_transcoder_connection_request)
@@ -9191,7 +9191,7 @@ Name | Type | Description  | Notes
 
 [**TestExternalTranscoderConnectionResponse**](TestExternalTranscoderConnectionResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **transition_workflow**
     def WorkflowTransitionResponse transition_workflow(workflow_transition_request)
@@ -9254,7 +9254,7 @@ Name | Type | Description  | Notes
 
 [**WorkflowTransitionResponse**](WorkflowTransitionResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **unbookmark_media_directory**
     def unbookmark_media_directory(id)
@@ -9302,7 +9302,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **unmark_media_directory_as_showroom**
     def unmark_media_directory_as_showroom(id)
@@ -9350,7 +9350,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **unresolve_comment**
     def Comment unresolve_comment(id)
@@ -9400,7 +9400,7 @@ Name | Type | Description  | Notes
 
 [**Comment**](Comment.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_asset**
     def Asset update_asset(id, asset_update)
@@ -9471,7 +9471,7 @@ Name | Type | Description  | Notes
 
 [**Asset**](Asset.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_asset_rating**
     def AssetRating update_asset_rating(id, asset_rating_update)
@@ -9530,7 +9530,7 @@ Name | Type | Description  | Notes
 
 [**AssetRating**](AssetRating.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_asset_subtitle_link**
     def AssetSubtitleLink update_asset_subtitle_link(id, asset_subtitle_link_update)
@@ -9605,7 +9605,7 @@ Name | Type | Description  | Notes
 
 [**AssetSubtitleLink**](AssetSubtitleLink.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_comment**
     def Comment update_comment(id, comment_update)
@@ -9677,7 +9677,7 @@ Name | Type | Description  | Notes
 
 [**Comment**](Comment.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_custom_field**
     def CustomField update_custom_field(id, custom_field_update)
@@ -9754,7 +9754,7 @@ Name | Type | Description  | Notes
 
 [**CustomField**](CustomField.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_editor_project**
     def EditorProject update_editor_project(id, editor_project_update)
@@ -9814,7 +9814,7 @@ Name | Type | Description  | Notes
 
 [**EditorProject**](EditorProject.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_editor_subtitle**
     def EditorSubtitle update_editor_subtitle(id, editor_subtitle_update)
@@ -9896,7 +9896,7 @@ Name | Type | Description  | Notes
 
 [**EditorSubtitle**](EditorSubtitle.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_external_transcoder**
     def ExternalTranscoder update_external_transcoder(id, external_transcoder_update)
@@ -9958,7 +9958,7 @@ Name | Type | Description  | Notes
 
 [**ExternalTranscoder**](ExternalTranscoder.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_marker**
     def Marker update_marker(id, marker_update)
@@ -10017,7 +10017,7 @@ Name | Type | Description  | Notes
 
 [**Marker**](Marker.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_media_file**
     def MediaFile update_media_file(id, media_file_update)
@@ -10092,7 +10092,7 @@ Name | Type | Description  | Notes
 
 [**MediaFile**](MediaFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_media_file_template**
     def MediaFileTemplate update_media_file_template(id, media_file_template_update)
@@ -10208,7 +10208,7 @@ Name | Type | Description  | Notes
 
 [**MediaFileTemplate**](MediaFileTemplate.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_media_root**
     def MediaRootDetail update_media_root(id, media_root_detail_update)
@@ -10317,7 +10317,7 @@ Name | Type | Description  | Notes
 
 [**MediaRootDetail**](MediaRootDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_media_root_permission**
     def MediaRootPermission update_media_root_permission(id, media_root_permission_update)
@@ -10396,7 +10396,7 @@ Name | Type | Description  | Notes
 
 [**MediaRootPermission**](MediaRootPermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_media_tag**
     def UnfilteredTag update_media_tag(id, unfiltered_tag_update)
@@ -10456,7 +10456,7 @@ Name | Type | Description  | Notes
 
 [**UnfilteredTag**](UnfilteredTag.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_proxy_profile**
     def ProxyProfile update_proxy_profile(id, proxy_profile_update)
@@ -10536,7 +10536,7 @@ Name | Type | Description  | Notes
 
 [**ProxyProfile**](ProxyProfile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_saved_search**
     def SavedSearch update_saved_search(id, saved_search_update)
@@ -10596,7 +10596,7 @@ Name | Type | Description  | Notes
 
 [**SavedSearch**](SavedSearch.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_subclip**
     def Subclip update_subclip(id, subclip_update)
@@ -10680,5 +10680,5 @@ Name | Type | Description  | Notes
 
 [**Subclip**](Subclip.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/MediaLibraryDeleteRequest.md
+++ b/docs/MediaLibraryDeleteRequest.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **delete_from_database** | **bool** |  | [optional]  if omitted the server will use the default value of False
 **delete_from_storage** | **bool** |  | [optional]  if omitted the server will use the default value of False
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaLibraryShareRequest.md
+++ b/docs/MediaLibraryShareRequest.md
@@ -15,6 +15,6 @@ Name | Type | Description | Notes
 **link_type** | **str** |  | [optional] 
 **password** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaRoot.md
+++ b/docs/MediaRoot.md
@@ -44,6 +44,6 @@ Name | Type | Description | Notes
 **jobs** | **[int]** |  | [optional] 
 **tags** | **[int]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaRootDetail.md
+++ b/docs/MediaRootDetail.md
@@ -45,6 +45,6 @@ Name | Type | Description | Notes
 **proxy_profiles** | **[int]** |  | [optional] 
 **tags** | **[int]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaRootDetailPartialUpdate.md
+++ b/docs/MediaRootDetailPartialUpdate.md
@@ -41,6 +41,6 @@ Name | Type | Description | Notes
 **proxy_profiles** | **[int]** |  | [optional] 
 **tags** | **[int]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaRootDetailUpdate.md
+++ b/docs/MediaRootDetailUpdate.md
@@ -41,6 +41,6 @@ Name | Type | Description | Notes
 **proxy_profiles** | **[int]** |  | [optional] 
 **tags** | **[int]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaRootMini.md
+++ b/docs/MediaRootMini.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **path** | **str** |  | [optional] 
 **prefetch_thumbnail_strips** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaRootMiniReference.md
+++ b/docs/MediaRootMiniReference.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **path** | **str** |  | [optional] 
 **prefetch_thumbnail_strips** | **bool** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaRootPartialUpdate.md
+++ b/docs/MediaRootPartialUpdate.md
@@ -39,6 +39,6 @@ Name | Type | Description | Notes
 **proxy_profiles** | **list[int]** |  | [optional] 
 **tags** | **list[int]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaRootPermission.md
+++ b/docs/MediaRootPermission.md
@@ -33,6 +33,6 @@ Name | Type | Description | Notes
 **show_history** | **bool** |  | [optional] 
 **is_temporary_for_token** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaRootPermissionAccessOptions.md
+++ b/docs/MediaRootPermissionAccessOptions.md
@@ -26,6 +26,6 @@ Name | Type | Description | Notes
 **allow_delete_fs** | **bool** |  | [optional] 
 **allow_delete_db** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaRootPermissionPartialUpdate.md
+++ b/docs/MediaRootPermissionPartialUpdate.md
@@ -31,6 +31,6 @@ Name | Type | Description | Notes
 **root** | **int** |  | [optional] 
 **is_temporary_for_token** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaRootPermissionUpdate.md
+++ b/docs/MediaRootPermissionUpdate.md
@@ -31,6 +31,6 @@ Name | Type | Description | Notes
 **show_history** | **bool** |  | [optional] 
 **is_temporary_for_token** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MediaUpdate.md
+++ b/docs/MediaUpdate.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **date** | **datetime** |  | [readonly] 
 **rating** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MemberPreview.md
+++ b/docs/MemberPreview.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **avatar** | **str, none_type** |  | 
 **email** | **str, none_type** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MetadataItem.md
+++ b/docs/MetadataItem.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **tags** | **[{str: (str, none_type)}]** |  | 
 **path** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MountedWorkspace.md
+++ b/docs/MountedWorkspace.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **user** | **int** |  | 
 **client_session** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MoveWorkspaceRequest.md
+++ b/docs/MoveWorkspaceRequest.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **volume** | **int** |  | [optional] 
 **directory** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/MultipleAssetsRequest.md
+++ b/docs/MultipleAssetsRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **assets** | **[int]** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/NFSPermission.md
+++ b/docs/NFSPermission.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **read_only** | **bool** |  | 
 **options** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/NTPServer.md
+++ b/docs/NTPServer.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **address** | **str** |  | 
 **options** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/NTPServerPartialUpdate.md
+++ b/docs/NTPServerPartialUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **address** | **str** |  | [optional] 
 **options** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/NTPServerUpdate.md
+++ b/docs/NTPServerUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **address** | **str** |  | 
 **options** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/NetStat.md
+++ b/docs/NetStat.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **c_rx_err** | **float** |  | 
 **c_tx_err** | **float** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Network.md
+++ b/docs/Network.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **use_for_mounts** | **bool** |  | [optional] 
 **priority** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/OneTimeAccessToken.md
+++ b/docs/OneTimeAccessToken.md
@@ -23,6 +23,6 @@ Name | Type | Description | Notes
 **expires** | **datetime, none_type** |  | [optional] 
 **require_login** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/OneTimeAccessTokenActivity.md
+++ b/docs/OneTimeAccessTokenActivity.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **ip** | **str** |  | 
 **token** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/OneTimeAccessTokenSharedObject.md
+++ b/docs/OneTimeAccessTokenSharedObject.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **id** | **int** |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Parameters.md
+++ b/docs/Parameters.md
@@ -34,6 +34,6 @@ Name | Type | Description | Notes
 **workspaces_folder_template_path** | **str** |  | [optional] 
 **workspaces_path** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ParametersUpdate.md
+++ b/docs/ParametersUpdate.md
@@ -34,6 +34,6 @@ Name | Type | Description | Notes
 **workspaces_folder_template_path** | **str** |  | [optional] 
 **workspaces_path** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ParseSAMLIDPMetadataRequest.md
+++ b/docs/ParseSAMLIDPMetadataRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **url** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ParsedSAMLIDPMetadata.md
+++ b/docs/ParsedSAMLIDPMetadata.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **certificate** | **str** |  | 
 **slo_url** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/PasswordResetEndpointRequest.md
+++ b/docs/PasswordResetEndpointRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **token** | **str** |  | 
 **password** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Path.md
+++ b/docs/Path.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **path** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/PathInput.md
+++ b/docs/PathInput.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **input** | **[str]** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/PrivateApi.md
+++ b/docs/PrivateApi.md
@@ -75,7 +75,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_veritone_tdo**
     def delete_veritone_tdo(id, tdo_id)
@@ -125,7 +125,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **export_non_proxied_assets**
     def export_non_proxied_assets(root_id)
@@ -173,7 +173,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **export_non_proxied_assets_for_path**
     def export_non_proxied_assets_for_path(path, root_id)
@@ -223,7 +223,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **export_updates**
     def export_updates(root_id)
@@ -271,7 +271,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get**
     def BootstrapData get()
@@ -317,7 +317,7 @@ This endpoint does not need any parameter.
 
 [**BootstrapData**](BootstrapData.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_veritone_connections**
     def [VeritoneConnection] get_all_veritone_connections()
@@ -372,7 +372,7 @@ Name | Type | Description  | Notes
 
 [**[VeritoneConnection]**](VeritoneConnection.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_veritone_metadata**
     def [VeritoneMetadata] get_all_veritone_metadata()
@@ -431,7 +431,7 @@ Name | Type | Description  | Notes
 
 [**[VeritoneMetadata]**](VeritoneMetadata.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_client_side_url**
     def ClientSidePathEndpointResponse get_client_side_url(client_side_path_endpoint_request)
@@ -485,7 +485,7 @@ Name | Type | Description  | Notes
 
 [**ClientSidePathEndpointResponse**](ClientSidePathEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_help_page**
     def HelpEndpointResponse get_help_page(id)
@@ -535,7 +535,7 @@ Name | Type | Description  | Notes
 
 [**HelpEndpointResponse**](HelpEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_locale**
     def LocaleEndpointResponse get_locale(lang)
@@ -585,7 +585,7 @@ Name | Type | Description  | Notes
 
 [**LocaleEndpointResponse**](LocaleEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_proxy_fs_size**
     def ProxyFSSizeEndpointResponse get_proxy_fs_size()
@@ -631,7 +631,7 @@ This endpoint does not need any parameter.
 
 [**ProxyFSSizeEndpointResponse**](ProxyFSSizeEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_stored_image**
     def get_stored_image(name)
@@ -679,7 +679,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_veritone_connection**
     def VeritoneConnection get_veritone_connection(id)
@@ -729,7 +729,7 @@ Name | Type | Description  | Notes
 
 [**VeritoneConnection**](VeritoneConnection.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_veritone_engines**
     def VeritoneEngineList get_veritone_engines(id)
@@ -779,7 +779,7 @@ Name | Type | Description  | Notes
 
 [**VeritoneEngineList**](VeritoneEngineList.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_veritone_jobs**
     def VeritoneJobList get_veritone_jobs(id)
@@ -841,7 +841,7 @@ Name | Type | Description  | Notes
 
 [**VeritoneJobList**](VeritoneJobList.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_veritone_metadata**
     def VeritoneMetadata get_veritone_metadata(id)
@@ -891,7 +891,7 @@ Name | Type | Description  | Notes
 
 [**VeritoneMetadata**](VeritoneMetadata.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **install_license**
     def install_license(install_license_endpoint_request)
@@ -943,7 +943,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **language_server_request**
     def {str: (bool, date, datetime, dict, float, int, list, str, none_type)} language_server_request(language)
@@ -992,7 +992,7 @@ Name | Type | Description  | Notes
 
 **{str: (bool, date, datetime, dict, float, int, list, str, none_type)}**
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **locate_file**
     def LocateResult locate_file(locate_endpoint_request)
@@ -1046,7 +1046,7 @@ Name | Type | Description  | Notes
 
 [**LocateResult**](LocateResult.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **locate_proxies**
     def [LocateProxiesEndpointResponse] locate_proxies(locate_proxies_endpoint_request)
@@ -1101,7 +1101,7 @@ Name | Type | Description  | Notes
 
 [**[LocateProxiesEndpointResponse]**](LocateProxiesEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **upload_stored_image**
     def upload_stored_image(upload_image_endpoint_request)
@@ -1153,7 +1153,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **upload_to_veritone**
     def upload_to_veritone(id, veritone_upload_request)
@@ -1208,5 +1208,5 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/Production.md
+++ b/docs/Production.md
@@ -17,6 +17,6 @@ Name | Type | Description | Notes
 **template** | **int, none_type** |  | [optional] 
 **default_group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ProductionMini.md
+++ b/docs/ProductionMini.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **special_type** | **int** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ProductionMiniReference.md
+++ b/docs/ProductionMiniReference.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | [optional] [readonly] 
 **special_type** | **int, none_type** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ProductionPartialUpdate.md
+++ b/docs/ProductionPartialUpdate.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **template** | **int, none_type** |  | [optional] 
 **default_group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ProductionReference.md
+++ b/docs/ProductionReference.md
@@ -17,6 +17,6 @@ Name | Type | Description | Notes
 **template** | **int, none_type** |  | [optional] [readonly] 
 **default_group** | **int, none_type** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ProductionUpdate.md
+++ b/docs/ProductionUpdate.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **template** | **int, none_type** |  | [optional] 
 **default_group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Proxy.md
+++ b/docs/Proxy.md
@@ -17,6 +17,6 @@ Name | Type | Description | Notes
 **variant_id** | **str** |  | [optional]  if omitted the server will use the default value of "default"
 **variant_config** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ProxyCount.md
+++ b/docs/ProxyCount.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **count** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ProxyFSSizeEndpointResponse.md
+++ b/docs/ProxyFSSizeEndpointResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **size** | **int, none_type** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ProxyGenerator.md
+++ b/docs/ProxyGenerator.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **properties** | [**ProxyGeneratorProperties**](ProxyGeneratorProperties.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ProxyGeneratorProperties.md
+++ b/docs/ProxyGeneratorProperties.md
@@ -16,6 +16,6 @@ Name | Type | Description | Notes
 **supports_audio_channels** | **bool** |  | [optional] 
 **supports_staging_path** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ProxyProfile.md
+++ b/docs/ProxyProfile.md
@@ -33,6 +33,6 @@ Name | Type | Description | Notes
 **external_transcoder_staging_path** | **str, none_type** |  | [optional] 
 **external_transcoder** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ProxyProfileMini.md
+++ b/docs/ProxyProfileMini.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **id** | **int** |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ProxyProfilePartialUpdate.md
+++ b/docs/ProxyProfilePartialUpdate.md
@@ -32,6 +32,6 @@ Name | Type | Description | Notes
 **external_transcoder_staging_path** | **str, none_type** |  | [optional] 
 **external_transcoder** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ProxyProfileUpdate.md
+++ b/docs/ProxyProfileUpdate.md
@@ -32,6 +32,6 @@ Name | Type | Description | Notes
 **external_transcoder_staging_path** | **str, none_type** |  | [optional] 
 **external_transcoder** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/PythonEnvironment.md
+++ b/docs/PythonEnvironment.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **version** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Queue.md
+++ b/docs/Queue.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **node** | [**StorageNodeMini**](StorageNodeMini.md) |  | [optional] 
 **volume** | [**VolumeMini**](VolumeMini.md) |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Quota.md
+++ b/docs/Quota.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **soft** | **int, none_type** |  | 
 **hard** | **int, none_type** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/RAMStat.md
+++ b/docs/RAMStat.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **c_cached** | **float** |  | 
 **c_buffered** | **float** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/RDCActivation.md
+++ b/docs/RDCActivation.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **session_id** | **str** |  | 
 **user** | [**ElementsUserMini**](ElementsUserMini.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/RDCHost.md
+++ b/docs/RDCHost.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **occupied** | **bool** |  | [readonly] 
 **last_updated** | **datetime** |  | [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/RDCSession.md
+++ b/docs/RDCSession.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **client_session** | **int** |  | 
 **host_workstation** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/RDCSessionCreate.md
+++ b/docs/RDCSessionCreate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **id** | **int** |  | 
 **user** | [**ElementsUserMiniReference**](ElementsUserMiniReference.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/RegisterUploadEndpointRequest.md
+++ b/docs/RegisterUploadEndpointRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **upload_id** | **str** |  | 
 **path** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/RegisterUploadMetadataEndpointRequest.md
+++ b/docs/RegisterUploadMetadataEndpointRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **items** | [**[MetadataItem]**](MetadataItem.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ReleaseNotesEndpointResponse.md
+++ b/docs/ReleaseNotesEndpointResponse.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **version** | **str** |  | 
 **html** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/RenameCustomFieldRequest.md
+++ b/docs/RenameCustomFieldRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/RenderEndpointRequest.md
+++ b/docs/RenderEndpointRequest.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **project** | **{str: (bool, date, datetime, dict, float, int, list, str, none_type)}** |  | 
 **options** | **{str: (bool, date, datetime, dict, float, int, list, str, none_type)}** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/RenderRequest.md
+++ b/docs/RenderRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **destination** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/RestoreEndpointRequest.md
+++ b/docs/RestoreEndpointRequest.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **start_date** | **datetime** |  | 
 **export** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SAMLProvider.md
+++ b/docs/SAMLProvider.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **sp_certificate** | **str, none_type** |  | [optional] 
 **sp_certificate_key** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SAMLProviderMini.md
+++ b/docs/SAMLProviderMini.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **logout_url** | **str** |  | [readonly] 
 **name** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SAMLProviderPartialUpdate.md
+++ b/docs/SAMLProviderPartialUpdate.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **sp_certificate** | **str, none_type** |  | [optional] 
 **sp_certificate_key** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SAMLProviderUpdate.md
+++ b/docs/SAMLProviderUpdate.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **sp_certificate** | **str, none_type** |  | [optional] 
 **sp_certificate_key** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SMTPConfiguration.md
+++ b/docs/SMTPConfiguration.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **username** | **str, none_type** |  | 
 **password** | **str, none_type** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SMTPConfigurationUpdate.md
+++ b/docs/SMTPConfigurationUpdate.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **username** | **str, none_type** |  | 
 **password** | **str, none_type** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SNFSStripeGroup.md
+++ b/docs/SNFSStripeGroup.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **size_used** | **int** |  | [optional] 
 **size_free** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SatelliteApi.md
+++ b/docs/SatelliteApi.md
@@ -62,7 +62,7 @@ Name | Type | Description  | Notes
 
 [**RDCActivation**](RDCActivation.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **announce_satellite_host**
     def RDCHost announce_satellite_host()
@@ -106,7 +106,7 @@ This endpoint does not need any parameter.
 
 [**RDCHost**](RDCHost.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_satellite_session**
     def RDCSession create_satellite_session(rdc_session_create)
@@ -162,7 +162,7 @@ Name | Type | Description  | Notes
 
 [**RDCSession**](RDCSession.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_satellite_session**
     def delete_satellite_session(id)
@@ -210,7 +210,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_satellite_hosts**
     def [RDCHost] get_all_satellite_hosts()
@@ -265,7 +265,7 @@ Name | Type | Description  | Notes
 
 [**[RDCHost]**](RDCHost.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_satellite_sessions**
     def [RDCSession] get_all_satellite_sessions()
@@ -320,7 +320,7 @@ Name | Type | Description  | Notes
 
 [**[RDCSession]**](RDCSession.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_satellite_host**
     def RDCHost get_satellite_host(id)
@@ -370,7 +370,7 @@ Name | Type | Description  | Notes
 
 [**RDCHost**](RDCHost.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_satellite_session**
     def RDCSession get_satellite_session(id)
@@ -420,5 +420,5 @@ Name | Type | Description  | Notes
 
 [**RDCSession**](RDCSession.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/SavedSearch.md
+++ b/docs/SavedSearch.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **root** | **bool, date, datetime, dict, float, int, list, str, none_type** |  | [optional] 
 **shared** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SavedSearchPartialUpdate.md
+++ b/docs/SavedSearchPartialUpdate.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | [optional] 
 **shared** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SavedSearchUpdate.md
+++ b/docs/SavedSearchUpdate.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **root** | **bool, date, datetime, dict, float, int, list, str, none_type** |  | [optional] 
 **shared** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ScannerDiscoverEndpointRequest.md
+++ b/docs/ScannerDiscoverEndpointRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **path** | **str** |  | 
 **recursive** | **bool, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ScannerScanEndpointRequest.md
+++ b/docs/ScannerScanEndpointRequest.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **notify** | **bool, none_type** |  | [optional] 
 **force_rescan** | **bool, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Schedule.md
+++ b/docs/Schedule.md
@@ -20,6 +20,6 @@ Name | Type | Description | Notes
 **crontab_minute** | **str** |  | [optional] 
 **crontab_month_of_year** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SchedulePartialUpdate.md
+++ b/docs/SchedulePartialUpdate.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **crontab_month_of_year** | **str** |  | [optional] 
 **job** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ScheduleReference.md
+++ b/docs/ScheduleReference.md
@@ -20,6 +20,6 @@ Name | Type | Description | Notes
 **crontab_month_of_year** | **str** |  | [optional] [readonly] 
 **job** | **int** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ScheduleUpdate.md
+++ b/docs/ScheduleUpdate.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **crontab_minute** | **str** |  | [optional] 
 **crontab_month_of_year** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SearchEndpointRequest.md
+++ b/docs/SearchEndpointRequest.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **names_only** | **bool** |  | [optional] 
 **tapes** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SearchEndpointResponse.md
+++ b/docs/SearchEndpointResponse.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **entries** | [**[TapeFile]**](TapeFile.md) |  | 
 **total** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SendLinkEmailRequest.md
+++ b/docs/SendLinkEmailRequest.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **subject** | **str** |  | [optional] 
 **text** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Sensor.md
+++ b/docs/Sensor.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **unit** | **str** |  | 
 **status** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Sensors.md
+++ b/docs/Sensors.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **sensors** | [**[Sensor]**](Sensor.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ServiceStatus.md
+++ b/docs/ServiceStatus.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **running** | **bool** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Share.md
+++ b/docs/Share.md
@@ -21,6 +21,6 @@ Name | Type | Description | Notes
 **rw_access_group** | **int, none_type** |  | [optional] 
 **ro_access_group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SharePartialUpdate.md
+++ b/docs/SharePartialUpdate.md
@@ -20,6 +20,6 @@ Name | Type | Description | Notes
 **rw_access_group** | **int, none_type** |  | [optional] 
 **ro_access_group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ShareToHomeWorkspaceEndpointRequest.md
+++ b/docs/ShareToHomeWorkspaceEndpointRequest.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **paths** | **[str]** |  | [optional] 
 **bundles** | **[int]** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/ShareUpdate.md
+++ b/docs/ShareUpdate.md
@@ -20,6 +20,6 @@ Name | Type | Description | Notes
 **rw_access_group** | **int, none_type** |  | [optional] 
 **ro_access_group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SharedstorageApi.md
+++ b/docs/SharedstorageApi.md
@@ -58,7 +58,7 @@ Name | Type | Description  | Notes
 
 [**StorageResponse**](StorageResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_user_storage_value**
     def StorageResponse get_user_storage_value(name)
@@ -108,7 +108,7 @@ Name | Type | Description  | Notes
 
 [**StorageResponse**](StorageResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **set_shared_storage_value**
     def StorageResponse set_shared_storage_value(name, storage_request)
@@ -164,7 +164,7 @@ Name | Type | Description  | Notes
 
 [**StorageResponse**](StorageResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **set_user_storage_value**
     def StorageResponse set_user_storage_value(name, storage_request)
@@ -220,5 +220,5 @@ Name | Type | Description  | Notes
 
 [**StorageResponse**](StorageResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/SlackChannel.md
+++ b/docs/SlackChannel.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **is_private** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SlackConnection.md
+++ b/docs/SlackConnection.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **status** | [**SlackConnectionStatus**](SlackConnectionStatus.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SlackConnectionPartialUpdate.md
+++ b/docs/SlackConnectionPartialUpdate.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SlackConnectionStatus.md
+++ b/docs/SlackConnectionStatus.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **user** | **str** |  | 
 **url** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SlackConnectionUpdate.md
+++ b/docs/SlackConnectionUpdate.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SlackEmoji.md
+++ b/docs/SlackEmoji.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **url** | **str** |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SlackMessage.md
+++ b/docs/SlackMessage.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **username** | **str, none_type** |  | [optional] 
 **emoji** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SlackUser.md
+++ b/docs/SlackUser.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **id** | **str** |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Snapshot.md
+++ b/docs/Snapshot.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **created_at** | **datetime** |  | [readonly] 
 **name** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SnapshotPartialUpdate.md
+++ b/docs/SnapshotPartialUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **workspace** | **int** |  | [optional] 
 **name** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SnapshotUpdate.md
+++ b/docs/SnapshotUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **workspace** | **int** |  | 
 **name** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SolrReindexEndpointResponse.md
+++ b/docs/SolrReindexEndpointResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **tasks** | [**[TaskInfo]**](TaskInfo.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StartJobRequest.md
+++ b/docs/StartJobRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **variables** | **{str: (str, none_type)}** |  | [optional] 
 **secret** | **str** | Only required for incoming webhooks | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StartTaskRequest.md
+++ b/docs/StartTaskRequest.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **parameters** | **{str: (str, none_type)}** |  | 
 **sync** | **bool** |  | [optional]  if omitted the server will use the default value of False
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Stats.md
+++ b/docs/Stats.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **net** | **{str: ([NetStat],)}** |  | 
 **io** | [**[IOStat]**](IOStat.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StatusApi.md
+++ b/docs/StatusApi.md
@@ -60,7 +60,7 @@ Name | Type | Description  | Notes
 
 [**Alert**](Alert.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_alerts**
     def [Alert] get_all_alerts()
@@ -119,7 +119,7 @@ Name | Type | Description  | Notes
 
 [**[Alert]**](Alert.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_telegraf_stats**
     def get_telegraf_stats()
@@ -163,7 +163,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_alert**
     def Alert patch_alert(id, alert_partial_update)
@@ -222,7 +222,7 @@ Name | Type | Description  | Notes
 
 [**Alert**](Alert.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **submit_kapacitor_alert**
     def submit_kapacitor_alert(kapacitor_alert)
@@ -277,7 +277,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_alert**
     def Alert update_alert(id, alert_update)
@@ -336,5 +336,5 @@ Name | Type | Description  | Notes
 
 [**Alert**](Alert.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/StorNextConnection.md
+++ b/docs/StorNextConnection.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **uptime** | **str** |  | [optional] 
 **license** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StorNextConnections.md
+++ b/docs/StorNextConnections.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **proxy** | **{str: (str, none_type)}** |  | 
 **gateway** | **{str: (str, none_type)}** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StorNextLicenseCheckEndpointResponse.md
+++ b/docs/StorNextLicenseCheckEndpointResponse.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **comment** | **str** |  | 
 **valid** | **bool** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StorNextLicenseEndpointResponse.md
+++ b/docs/StorNextLicenseEndpointResponse.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **expiry** | **str** |  | 
 **capacity** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StorageApi.md
+++ b/docs/StorageApi.md
@@ -123,7 +123,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **bookmark_workspace**
     def bookmark_workspace(id)
@@ -171,7 +171,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **calculate_directory_size**
     def FileSizeEndpointResponse calculate_directory_size(path_input)
@@ -226,7 +226,7 @@ Name | Type | Description  | Notes
 
 [**FileSizeEndpointResponse**](FileSizeEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **check_in_into_workspace**
     def check_in_into_workspace(id, workspace_check_in)
@@ -281,7 +281,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **check_out_of_workspace**
     def check_out_of_workspace(id)
@@ -329,7 +329,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **copy_files**
     def TaskInfo copy_files(file_copy_endpoint_request)
@@ -389,7 +389,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_file**
     def FilesystemFile create_file(file_update)
@@ -470,7 +470,7 @@ Name | Type | Description  | Notes
 
 [**FilesystemFile**](FilesystemFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_path_quota**
     def create_path_quota(id, relative_path, create_path_quota_request)
@@ -525,7 +525,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_production**
     def Production create_production(production_update)
@@ -584,7 +584,7 @@ Name | Type | Description  | Notes
 
 [**Production**](Production.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_share**
     def Share create_share(share_update)
@@ -790,7 +790,7 @@ Name | Type | Description  | Notes
 
 [**Share**](Share.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_snapshot**
     def Snapshot create_snapshot(snapshot_update)
@@ -844,7 +844,7 @@ Name | Type | Description  | Notes
 
 [**Snapshot**](Snapshot.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_template_folder**
     def create_template_folder(create_template_folder_endpoint_request)
@@ -897,7 +897,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_volume**
     def Volume create_volume(volume_update)
@@ -963,7 +963,7 @@ Name | Type | Description  | Notes
 
 [**Volume**](Volume.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_workspace**
     def WorkspaceDetail create_workspace(workspace_detail_update)
@@ -1063,7 +1063,7 @@ Name | Type | Description  | Notes
 
 [**WorkspaceDetail**](WorkspaceDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_workspace_permission**
     def WorkspacePermission create_workspace_permission(workspace_permission_update)
@@ -1119,7 +1119,7 @@ Name | Type | Description  | Notes
 
 [**WorkspacePermission**](WorkspacePermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_file**
     def delete_file(path)
@@ -1167,7 +1167,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_files**
     def TaskInfo delete_files(file_delete_endpoint_request)
@@ -1223,7 +1223,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_path_quota**
     def delete_path_quota(id, relative_path)
@@ -1273,7 +1273,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_production**
     def delete_production(id)
@@ -1321,7 +1321,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_share**
     def delete_share(id)
@@ -1369,7 +1369,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_snapshot**
     def delete_snapshot(id)
@@ -1417,7 +1417,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_workspace**
     def delete_workspace(id)
@@ -1474,7 +1474,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_workspace_permission**
     def delete_workspace_permission(id)
@@ -1522,7 +1522,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_deleted_workspaces**
     def [DeletedWorkspace] get_all_deleted_workspaces()
@@ -1597,7 +1597,7 @@ Name | Type | Description  | Notes
 
 [**[DeletedWorkspace]**](DeletedWorkspace.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_productions**
     def [Production] get_all_productions()
@@ -1660,7 +1660,7 @@ Name | Type | Description  | Notes
 
 [**[Production]**](Production.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_shares**
     def [Share] get_all_shares()
@@ -1715,7 +1715,7 @@ Name | Type | Description  | Notes
 
 [**[Share]**](Share.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_snapshots**
     def [Snapshot] get_all_snapshots()
@@ -1772,7 +1772,7 @@ Name | Type | Description  | Notes
 
 [**[Snapshot]**](Snapshot.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_volumes**
     def [Volume] get_all_volumes()
@@ -1841,7 +1841,7 @@ Name | Type | Description  | Notes
 
 [**[Volume]**](Volume.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_workspace_permissions**
     def [WorkspacePermission] get_all_workspace_permissions()
@@ -1902,7 +1902,7 @@ Name | Type | Description  | Notes
 
 [**[WorkspacePermission]**](WorkspacePermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_workspaces**
     def [Workspace] get_all_workspaces()
@@ -1983,7 +1983,7 @@ Name | Type | Description  | Notes
 
 [**[Workspace]**](Workspace.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_file**
     def FilesystemFile get_file(path)
@@ -2045,7 +2045,7 @@ Name | Type | Description  | Notes
 
 [**FilesystemFile**](FilesystemFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_group_quota**
     def Quota get_group_quota(group_id, id)
@@ -2097,7 +2097,7 @@ Name | Type | Description  | Notes
 
 [**Quota**](Quota.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_my_workspaces**
     def [Workspace] get_my_workspaces()
@@ -2172,7 +2172,7 @@ Name | Type | Description  | Notes
 
 [**[Workspace]**](Workspace.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_path_quota**
     def Quota get_path_quota(id, relative_path)
@@ -2224,7 +2224,7 @@ Name | Type | Description  | Notes
 
 [**Quota**](Quota.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_production**
     def Production get_production(id)
@@ -2286,7 +2286,7 @@ Name | Type | Description  | Notes
 
 [**Production**](Production.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_root_directory**
     def get_root_directory()
@@ -2340,7 +2340,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_samba_dfree_string**
     def get_samba_dfree_string()
@@ -2384,7 +2384,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_share**
     def Share get_share(id)
@@ -2434,7 +2434,7 @@ Name | Type | Description  | Notes
 
 [**Share**](Share.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_snapshot**
     def Snapshot get_snapshot(id)
@@ -2484,7 +2484,7 @@ Name | Type | Description  | Notes
 
 [**Snapshot**](Snapshot.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_user_quota**
     def Quota get_user_quota(id, user_id)
@@ -2536,7 +2536,7 @@ Name | Type | Description  | Notes
 
 [**Quota**](Quota.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_volume**
     def Volume get_volume(id)
@@ -2596,7 +2596,7 @@ Name | Type | Description  | Notes
 
 [**Volume**](Volume.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_volume_active_connections**
     def StorNextConnections get_volume_active_connections(id)
@@ -2646,7 +2646,7 @@ Name | Type | Description  | Notes
 
 [**StorNextConnections**](StorNextConnections.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_volume_file_size_distribution**
     def FileSizeDistribution get_volume_file_size_distribution(id)
@@ -2696,7 +2696,7 @@ Name | Type | Description  | Notes
 
 [**FileSizeDistribution**](FileSizeDistribution.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_volume_stats**
     def VolumeStats get_volume_stats(id)
@@ -2746,7 +2746,7 @@ Name | Type | Description  | Notes
 
 [**VolumeStats**](VolumeStats.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_workspace**
     def WorkspaceDetail get_workspace(id)
@@ -2796,7 +2796,7 @@ Name | Type | Description  | Notes
 
 [**WorkspaceDetail**](WorkspaceDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_workspace_permission**
     def WorkspacePermission get_workspace_permission(id)
@@ -2846,7 +2846,7 @@ Name | Type | Description  | Notes
 
 [**WorkspacePermission**](WorkspacePermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **move_files**
     def TaskInfo move_files(file_move_endpoint_request)
@@ -2904,7 +2904,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **move_workspace**
     def TaskInfo move_workspace(id, move_workspace_request)
@@ -2961,7 +2961,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **move_workspace_to_production**
     def move_workspace_to_production(id, workspace_move_to_request)
@@ -3014,7 +3014,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_file**
     def FilesystemFile patch_file(path, file_partial_update)
@@ -3109,7 +3109,7 @@ Name | Type | Description  | Notes
 
 [**FilesystemFile**](FilesystemFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_production**
     def Production patch_production(id, production_partial_update)
@@ -3170,7 +3170,7 @@ Name | Type | Description  | Notes
 
 [**Production**](Production.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_share**
     def Share patch_share(id, share_partial_update)
@@ -3378,7 +3378,7 @@ Name | Type | Description  | Notes
 
 [**Share**](Share.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_snapshot**
     def Snapshot patch_snapshot(id, snapshot_partial_update)
@@ -3434,7 +3434,7 @@ Name | Type | Description  | Notes
 
 [**Snapshot**](Snapshot.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_volume**
     def Volume patch_volume(id, volume_partial_update)
@@ -3502,7 +3502,7 @@ Name | Type | Description  | Notes
 
 [**Volume**](Volume.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_workspace**
     def WorkspaceDetail patch_workspace(id, workspace_detail_partial_update)
@@ -3604,7 +3604,7 @@ Name | Type | Description  | Notes
 
 [**WorkspaceDetail**](WorkspaceDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_workspace_permission**
     def WorkspacePermission patch_workspace_permission(id, workspace_permission_partial_update)
@@ -3662,7 +3662,7 @@ Name | Type | Description  | Notes
 
 [**WorkspacePermission**](WorkspacePermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **record_storage_trace**
     def FilesystemTraceEndpointResponse record_storage_trace(filesystem_trace_endpoint_request)
@@ -3715,7 +3715,7 @@ Name | Type | Description  | Notes
 
 [**FilesystemTraceEndpointResponse**](FilesystemTraceEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **repair_workspace_permissions**
     def TaskInfo repair_workspace_permissions(id)
@@ -3765,7 +3765,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **share_to_home_workspace**
     def share_to_home_workspace(share_to_home_workspace_endpoint_request)
@@ -3823,7 +3823,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **unbookmark_workspace**
     def unbookmark_workspace(id)
@@ -3871,7 +3871,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **unzip_file**
     def TaskInfo unzip_file(file_unzip_endpoint_request)
@@ -3925,7 +3925,7 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_group_quota**
     def update_group_quota(group_id, id, update_quota_request)
@@ -3981,7 +3981,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_path_quota**
     def update_path_quota(id, relative_path, update_quota_request)
@@ -4037,7 +4037,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_production**
     def Production update_production(id, production_update)
@@ -4098,7 +4098,7 @@ Name | Type | Description  | Notes
 
 [**Production**](Production.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_share**
     def Share update_share(id, share_update)
@@ -4306,7 +4306,7 @@ Name | Type | Description  | Notes
 
 [**Share**](Share.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_snapshot**
     def Snapshot update_snapshot(id, snapshot_update)
@@ -4362,7 +4362,7 @@ Name | Type | Description  | Notes
 
 [**Snapshot**](Snapshot.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_user_quota**
     def update_user_quota(id, user_id, update_quota_request)
@@ -4418,7 +4418,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_volume**
     def Volume update_volume(id, volume_update)
@@ -4486,7 +4486,7 @@ Name | Type | Description  | Notes
 
 [**Volume**](Volume.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_workspace**
     def WorkspaceDetail update_workspace(id, workspace_detail_update)
@@ -4588,7 +4588,7 @@ Name | Type | Description  | Notes
 
 [**WorkspaceDetail**](WorkspaceDetail.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_workspace_permission**
     def WorkspacePermission update_workspace_permission(id, workspace_permission_update)
@@ -4646,7 +4646,7 @@ Name | Type | Description  | Notes
 
 [**WorkspacePermission**](WorkspacePermission.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **zip_files**
     def TaskInfo zip_files(file_zip_endpoint_request)
@@ -4703,5 +4703,5 @@ Name | Type | Description  | Notes
 
 [**TaskInfo**](TaskInfo.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/StorageNode.md
+++ b/docs/StorageNode.md
@@ -16,6 +16,6 @@ Name | Type | Description | Notes
 **ipmi** | **int** |  | [optional] 
 **status** | [**StorageNodeStatus**](StorageNodeStatus.md) |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StorageNodeMini.md
+++ b/docs/StorageNodeMini.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **address** | **str** | For communication between nodes only | [optional] 
 **type** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StorageNodeStatus.md
+++ b/docs/StorageNodeStatus.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **ha_status** | **str, none_type** |  | 
 **ha_ips** | **[str]** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StorageRequest.md
+++ b/docs/StorageRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **value** | **str, none_type** |  | 
 **initiator** | **str, none_type** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StorageResponse.md
+++ b/docs/StorageResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | **str, none_type** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StorageRoot.md
+++ b/docs/StorageRoot.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **path** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StornextLicense.md
+++ b/docs/StornextLicense.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **license** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/StornextManagerAttributes.md
+++ b/docs/StornextManagerAttributes.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **existing_copies** | **int** |  | 
 **target_copies** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Subclip.md
+++ b/docs/Subclip.md
@@ -16,6 +16,6 @@ Name | Type | Description | Notes
 **shared** | **bool** |  | [optional] 
 **name** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SubclipClipboardEntry.md
+++ b/docs/SubclipClipboardEntry.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **date** | **datetime** |  | [readonly] 
 **bundle** | **bool, date, datetime, dict, float, int, list, str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SubclipClipboardEntryUpdate.md
+++ b/docs/SubclipClipboardEntryUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **cut** | [**SubclipReference**](SubclipReference.md) |  | 
 **bundle** | **bool, date, datetime, dict, float, int, list, str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SubclipPartialUpdate.md
+++ b/docs/SubclipPartialUpdate.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **t_in** | **float** |  | [optional] 
 **t_out** | **float** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SubclipReference.md
+++ b/docs/SubclipReference.md
@@ -16,6 +16,6 @@ Name | Type | Description | Notes
 **t_out** | **float** |  | [optional] [readonly] 
 **user** | **int** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SubclipUpdate.md
+++ b/docs/SubclipUpdate.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **shared** | **bool** |  | [optional] 
 **name** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Subscription.md
+++ b/docs/Subscription.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **id** | **str** |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Subtask.md
+++ b/docs/Subtask.md
@@ -24,6 +24,6 @@ Name | Type | Description | Notes
 **enqueue_at_front** | **bool** |  | [optional] 
 **relative_to** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SubtaskPartialUpdate.md
+++ b/docs/SubtaskPartialUpdate.md
@@ -22,6 +22,6 @@ Name | Type | Description | Notes
 **parent** | **int** |  | [optional] 
 **relative_to** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SubtaskReference.md
+++ b/docs/SubtaskReference.md
@@ -24,6 +24,6 @@ Name | Type | Description | Notes
 **parent** | **int** |  | [optional] [readonly] 
 **relative_to** | **int, none_type** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SubtaskUpdate.md
+++ b/docs/SubtaskUpdate.md
@@ -22,6 +22,6 @@ Name | Type | Description | Notes
 **enqueue_at_front** | **bool** |  | [optional] 
 **relative_to** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Subtitle.md
+++ b/docs/Subtitle.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **styles** | **{str: (str, none_type)}** |  | [optional] 
 **events** | [**[SubtitleEvent]**](SubtitleEvent.md) |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SubtitleClipboardEntry.md
+++ b/docs/SubtitleClipboardEntry.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **date** | **datetime** |  | [readonly] 
 **bundle** | **bool, date, datetime, dict, float, int, list, str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SubtitleClipboardEntryUpdate.md
+++ b/docs/SubtitleClipboardEntryUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **subtitle** | [**AssetMiniReference**](AssetMiniReference.md) |  | 
 **bundle** | **bool, date, datetime, dict, float, int, list, str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SubtitleEvent.md
+++ b/docs/SubtitleEvent.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **effect** | **str** |  | [optional] 
 **type** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SyncTOTP.md
+++ b/docs/SyncTOTP.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **drift** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SyncTOTPRequest.md
+++ b/docs/SyncTOTPRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **otp** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/SystemInfoEndpointResponse.md
+++ b/docs/SystemInfoEndpointResponse.md
@@ -15,6 +15,6 @@ Name | Type | Description | Notes
 **version** | [**ElementsVersion**](ElementsVersion.md) |  | 
 **global_alerts** | [**[GlobalAlert]**](GlobalAlert.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Tag.md
+++ b/docs/Tag.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **color** | **str** |  | [optional] 
 **root** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TagMediaDirectoryRequest.md
+++ b/docs/TagMediaDirectoryRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **tag** | **int** |  | 
 **add** | **bool** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TagPartialUpdate.md
+++ b/docs/TagPartialUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **color** | **str** |  | [optional] 
 **root** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TagReference.md
+++ b/docs/TagReference.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **shared** | **bool** |  | [optional] [readonly] 
 **color** | **str** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Tape.md
+++ b/docs/Tape.md
@@ -22,6 +22,6 @@ Name | Type | Description | Notes
 **lto** | **str, none_type** |  | [optional] 
 **group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeArchiveApi.md
+++ b/docs/TapeArchiveApi.md
@@ -105,7 +105,7 @@ Name | Type | Description  | Notes
 
 [**[TapeJob]**](TapeJob.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **cancel_all_tape_archive_jobs**
     def cancel_all_tape_archive_jobs()
@@ -149,7 +149,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **check_tape**
     def check_tape(tape_library_fsck_endpoint_request)
@@ -200,7 +200,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_tape**
     def Tape create_tape(tape_update)
@@ -266,7 +266,7 @@ Name | Type | Description  | Notes
 
 [**Tape**](Tape.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **create_tape_group**
     def TapeGroup create_tape_group(tape_group_update)
@@ -324,7 +324,7 @@ Name | Type | Description  | Notes
 
 [**TapeGroup**](TapeGroup.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_tape**
     def delete_tape(id)
@@ -372,7 +372,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_tape_archive_job**
     def delete_tape_archive_job(id)
@@ -420,7 +420,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **delete_tape_group**
     def delete_tape_group(id)
@@ -468,7 +468,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **format_tape**
     def format_tape(tape_library_format_endpoint_request)
@@ -519,7 +519,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_archived_file_entries**
     def [TapeFile] get_all_archived_file_entries()
@@ -584,7 +584,7 @@ Name | Type | Description  | Notes
 
 [**[TapeFile]**](TapeFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_tape_archive_jobs**
     def [TapeJob] get_all_tape_archive_jobs()
@@ -639,7 +639,7 @@ Name | Type | Description  | Notes
 
 [**[TapeJob]**](TapeJob.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_tape_groups**
     def [TapeGroup] get_all_tape_groups()
@@ -698,7 +698,7 @@ Name | Type | Description  | Notes
 
 [**[TapeGroup]**](TapeGroup.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_all_tapes**
     def [Tape] get_all_tapes()
@@ -761,7 +761,7 @@ Name | Type | Description  | Notes
 
 [**[Tape]**](Tape.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_archived_file_entry**
     def TapeFile get_archived_file_entry(id)
@@ -811,7 +811,7 @@ Name | Type | Description  | Notes
 
 [**TapeFile**](TapeFile.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_tape**
     def Tape get_tape(id)
@@ -861,7 +861,7 @@ Name | Type | Description  | Notes
 
 [**Tape**](Tape.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_tape_archive_job**
     def TapeJob get_tape_archive_job(id)
@@ -911,7 +911,7 @@ Name | Type | Description  | Notes
 
 [**TapeJob**](TapeJob.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_tape_archive_job_sources**
     def [TapeJobSource] get_tape_archive_job_sources(id)
@@ -961,7 +961,7 @@ Name | Type | Description  | Notes
 
 [**[TapeJobSource]**](TapeJobSource.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_tape_group**
     def TapeGroup get_tape_group(id)
@@ -1011,7 +1011,7 @@ Name | Type | Description  | Notes
 
 [**TapeGroup**](TapeGroup.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **get_tape_library_state**
     def TapeLibraryEndpointResponse get_tape_library_state()
@@ -1057,7 +1057,7 @@ This endpoint does not need any parameter.
 
 [**TapeLibraryEndpointResponse**](TapeLibraryEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **load_tape**
     def load_tape(tape_library_load_endpoint_request)
@@ -1108,7 +1108,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **move_tape**
     def move_tape(tape_library_move_endpoint_request)
@@ -1160,7 +1160,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_tape**
     def Tape patch_tape(id, tape_partial_update)
@@ -1228,7 +1228,7 @@ Name | Type | Description  | Notes
 
 [**Tape**](Tape.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **patch_tape_group**
     def TapeGroup patch_tape_group(id, tape_group_partial_update)
@@ -1288,7 +1288,7 @@ Name | Type | Description  | Notes
 
 [**TapeGroup**](TapeGroup.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **pause_tape_archive_job**
     def pause_tape_archive_job(id)
@@ -1336,7 +1336,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **refresh_tape_library_state**
     def refresh_tape_library_state()
@@ -1380,7 +1380,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **reindex_tape**
     def reindex_tape(tape_library_reindex_endpoint_request)
@@ -1431,7 +1431,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **remove_finished_tape_archive_jobs**
     def remove_finished_tape_archive_jobs()
@@ -1475,7 +1475,7 @@ This endpoint does not need any parameter.
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **restart_tape_archive_job**
     def restart_tape_archive_job(id)
@@ -1523,7 +1523,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **restore_from_tape**
     def TapeJob restore_from_tape(restore_endpoint_request)
@@ -1591,7 +1591,7 @@ Name | Type | Description  | Notes
 
 [**TapeJob**](TapeJob.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **resume_tape_archive_job**
     def resume_tape_archive_job(id)
@@ -1639,7 +1639,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **search_tape_archive**
     def SearchEndpointResponse search_tape_archive(search_endpoint_request)
@@ -1698,7 +1698,7 @@ Name | Type | Description  | Notes
 
 [**SearchEndpointResponse**](SearchEndpointResponse.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **unload_tape**
     def unload_tape(tape_library_unload_endpoint_request)
@@ -1749,7 +1749,7 @@ Name | Type | Description  | Notes
 
 void (empty response body)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_tape**
     def Tape update_tape(id, tape_update)
@@ -1817,7 +1817,7 @@ Name | Type | Description  | Notes
 
 [**Tape**](Tape.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 
 # **update_tape_group**
     def TapeGroup update_tape_group(id, tape_group_update)
@@ -1877,5 +1877,5 @@ Name | Type | Description  | Notes
 
 [**TapeGroup**](TapeGroup.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/TapeFile.md
+++ b/docs/TapeFile.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **fullpath** | **str, none_type** |  | [optional] 
 **parent** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeGroup.md
+++ b/docs/TapeGroup.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **tapes** | [**[TapeReference]**](TapeReference.md) |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeGroupPartialUpdate.md
+++ b/docs/TapeGroupPartialUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **tapes** | [**[TapeReference]**](TapeReference.md) |  | [optional] 
 **name** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeGroupUpdate.md
+++ b/docs/TapeGroupUpdate.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **tapes** | [**[TapeReference]**](TapeReference.md) |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeJob.md
+++ b/docs/TapeJob.md
@@ -29,6 +29,6 @@ Name | Type | Description | Notes
 **log_path** | **str, none_type** |  | [optional] 
 **log_exists** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeJobSource.md
+++ b/docs/TapeJobSource.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **options** | **{str: (str, none_type)}, none_type** |  | [optional] 
 **include** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeLibraryEndpointResponse.md
+++ b/docs/TapeLibraryEndpointResponse.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **mailbox** | [**[TapeLibrarySlot]**](TapeLibrarySlot.md) |  | 
 **slots** | [**[TapeLibrarySlot]**](TapeLibrarySlot.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeLibraryFormatEndpointRequest.md
+++ b/docs/TapeLibraryFormatEndpointRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **barcode** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeLibraryFsckEndpointRequest.md
+++ b/docs/TapeLibraryFsckEndpointRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **barcode** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeLibraryLoadEndpointRequest.md
+++ b/docs/TapeLibraryLoadEndpointRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **barcode** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeLibraryMoveEndpointRequest.md
+++ b/docs/TapeLibraryMoveEndpointRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **barcode** | **str** |  | 
 **slot** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeLibraryReindexEndpointRequest.md
+++ b/docs/TapeLibraryReindexEndpointRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **barcode** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeLibrarySlot.md
+++ b/docs/TapeLibrarySlot.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **origin** | **str** |  | [optional] 
 **locked** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeLibraryUnloadEndpointRequest.md
+++ b/docs/TapeLibraryUnloadEndpointRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **barcode** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapePartialUpdate.md
+++ b/docs/TapePartialUpdate.md
@@ -20,6 +20,6 @@ Name | Type | Description | Notes
 **lto** | **str, none_type** |  | [optional] 
 **group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeReference.md
+++ b/docs/TapeReference.md
@@ -22,6 +22,6 @@ Name | Type | Description | Notes
 **lto** | **str, none_type** |  | [optional] [readonly] 
 **group** | **int, none_type** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TapeUpdate.md
+++ b/docs/TapeUpdate.md
@@ -20,6 +20,6 @@ Name | Type | Description | Notes
 **lto** | **str, none_type** |  | [optional] 
 **group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TaskInfo.md
+++ b/docs/TaskInfo.md
@@ -27,6 +27,6 @@ Name | Type | Description | Notes
 **traceback** | **str, none_type** |  | [optional] 
 **schedule** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TaskLog.md
+++ b/docs/TaskLog.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **log** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TaskProgress.md
+++ b/docs/TaskProgress.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **max** | **int, none_type** |  | [optional] 
 **bar** | **bool, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TaskType.md
+++ b/docs/TaskType.md
@@ -22,6 +22,6 @@ Name | Type | Description | Notes
 **allow_in_jobs** | **bool** |  | 
 **new_since_version** | **str, none_type** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TasksApi.md
+++ b/docs/TasksApi.md
@@ -54,5 +54,5 @@ This endpoint does not need any parameters.
 
 [**list[PythonEnvironment]**](PythonEnvironment.md)
 
-[[Back to top]](#) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to Model list]](../#documentation-for-models) [[Back to README]](../)
+[[Back to top]](#) [[Back to API list]](../README.md#api-endpoints) [[Back to Model list]](../README.md#models) [[Back to README]](../README.md)
 

--- a/docs/TasksSummary.md
+++ b/docs/TasksSummary.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **recent_finished** | [**[TaskInfo]**](TaskInfo.md) |  | 
 **pending_count** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TeamsConnection.md
+++ b/docs/TeamsConnection.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **status** | [**TeamsConnectionStatus**](TeamsConnectionStatus.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TeamsConnectionPartialUpdate.md
+++ b/docs/TeamsConnectionPartialUpdate.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TeamsConnectionStatus.md
+++ b/docs/TeamsConnectionStatus.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **ok** | **bool** |  | 
 **team** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TeamsConnectionUpdate.md
+++ b/docs/TeamsConnectionUpdate.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TeamsMessage.md
+++ b/docs/TeamsMessage.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **recipient** | **str** |  | 
 **text** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TeamsRecipient.md
+++ b/docs/TeamsRecipient.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **id** | **str** |  | 
 **name** | **str** |  | [optional]  if omitted the server will use the default value of "General"
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TestAWSCredentialsRequest.md
+++ b/docs/TestAWSCredentialsRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **access_key_id** | **str** |  | 
 **secret_access_key** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TestAWSCredentialsResponse.md
+++ b/docs/TestAWSCredentialsResponse.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **account** | **str** |  | [optional] 
 **user_id** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TestCloudAccountCredentialsRequest.md
+++ b/docs/TestCloudAccountCredentialsRequest.md
@@ -14,6 +14,6 @@ Name | Type | Description | Notes
 **endpoint** | **str, none_type** |  | [optional] 
 **mount_credentials_management** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TestCloudAccountCredentialsResponse.md
+++ b/docs/TestCloudAccountCredentialsResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **subscriptions** | [**[Subscription]**](Subscription.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TestExternalTranscoderConnectionRequest.md
+++ b/docs/TestExternalTranscoderConnectionRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **type** | **str** |  | 
 **address** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TestExternalTranscoderConnectionResponse.md
+++ b/docs/TestExternalTranscoderConnectionResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ok** | **bool** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TestSMTP.md
+++ b/docs/TestSMTP.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **email** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Ticket.md
+++ b/docs/Ticket.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ticket** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TimeEndpointRequest.md
+++ b/docs/TimeEndpointRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **time** | **float** |  | 
 **timezone** | [**Timezone**](Timezone.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TimeEndpointResponse.md
+++ b/docs/TimeEndpointResponse.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **timezone** | [**Timezone**](Timezone.md) |  | 
 **timezones** | [**[Timezone]**](Timezone.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TimeSyncEndpointRequest.md
+++ b/docs/TimeSyncEndpointRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **server** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TimeSyncEndpointResponse.md
+++ b/docs/TimeSyncEndpointResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **output** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TimelineExportRequest.md
+++ b/docs/TimelineExportRequest.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **format** | **str** |  | 
 **sequence** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Timezone.md
+++ b/docs/Timezone.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **value** | **str** |  | 
 **name** | **str** |  | [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TraceNode.md
+++ b/docs/TraceNode.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **w** | **int** |  | [optional] 
 **total_children** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TranscoderProfile.md
+++ b/docs/TranscoderProfile.md
@@ -15,6 +15,6 @@ Name | Type | Description | Notes
 **accepts_fps** | **bool** |  | [optional] 
 **accepts_resolution** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/TypeDocumentation.md
+++ b/docs/TypeDocumentation.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **url** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/UnfilteredTag.md
+++ b/docs/UnfilteredTag.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **shared** | **bool** |  | [optional] 
 **color** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/UnfilteredTagPartialUpdate.md
+++ b/docs/UnfilteredTagPartialUpdate.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **shared** | **bool** |  | [optional] 
 **color** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/UnfilteredTagUpdate.md
+++ b/docs/UnfilteredTagUpdate.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **shared** | **bool** |  | [optional] 
 **color** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/UpdateQuotaRequest.md
+++ b/docs/UpdateQuotaRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **soft** | **int, none_type** |  | [optional] 
 **hard** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/UploadAIImageRequest.md
+++ b/docs/UploadAIImageRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **content** | **str** |  | 
 **category** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/UploadChunkEndpointRequest.md
+++ b/docs/UploadChunkEndpointRequest.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **chunk_number** | **int** |  | [optional] 
 **total_chunks** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/UploadImageEndpointRequest.md
+++ b/docs/UploadImageEndpointRequest.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | 
 **data** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/UserPreviewRequest.md
+++ b/docs/UserPreviewRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **username** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/UserPreviewResponse.md
+++ b/docs/UserPreviewResponse.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **avatar** | **str** |  | 
 **username** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VantageWorkflow.md
+++ b/docs/VantageWorkflow.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **id** | **str** |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VantageWorkflows.md
+++ b/docs/VantageWorkflows.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **workflows** | [**[VantageWorkflow]**](VantageWorkflow.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VeritoneConnection.md
+++ b/docs/VeritoneConnection.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **id** | **int** |  | 
 **name** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VeritoneEngineList.md
+++ b/docs/VeritoneEngineList.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **engines** | **[{str: (str, none_type)}]** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VeritoneJobList.md
+++ b/docs/VeritoneJobList.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **jobs** | **[{str: (str, none_type)}]** |  | 
 **count** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VeritoneMetadata.md
+++ b/docs/VeritoneMetadata.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **is_parsed** | **bool** |  | [optional] 
 **parser** | **str, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VeritoneUploadRequest.md
+++ b/docs/VeritoneUploadRequest.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **file** | **int, none_type** |  | [optional] 
 **bundle** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Volume.md
+++ b/docs/Volume.md
@@ -23,6 +23,6 @@ Name | Type | Description | Notes
 **cloud_account** | **int, none_type** |  | [optional] 
 **name** | **str, none_type** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VolumeBeeGFSStatus.md
+++ b/docs/VolumeBeeGFSStatus.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **nodes** | [**[BeeGFSNode]**](BeeGFSNode.md) |  | 
 **targets** | [**[BeeGFSTarget]**](BeeGFSTarget.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VolumeLizardFSStatus.md
+++ b/docs/VolumeLizardFSStatus.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **nodes** | [**[LizardFSNode]**](LizardFSNode.md) |  | 
 **disks** | [**[LizardFSDisk]**](LizardFSDisk.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VolumeMini.md
+++ b/docs/VolumeMini.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **type** | **str** |  | [optional] 
 **name** | **str, none_type** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VolumeMiniReference.md
+++ b/docs/VolumeMiniReference.md
@@ -12,6 +12,6 @@ Name | Type | Description | Notes
 **type** | **str** |  | [optional] [readonly] 
 **name** | **str, none_type** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VolumePartialUpdate.md
+++ b/docs/VolumePartialUpdate.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **simulated_quotas** | **bool** |  | [optional] 
 **cloud_account** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VolumeReference.md
+++ b/docs/VolumeReference.md
@@ -23,6 +23,6 @@ Name | Type | Description | Notes
 **cloud_account** | **int, none_type** |  | [optional] [readonly] 
 **name** | **str, none_type** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VolumeSNFSStatus.md
+++ b/docs/VolumeSNFSStatus.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **stripe_groups** | [**[SNFSStripeGroup]**](SNFSStripeGroup.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VolumeStat.md
+++ b/docs/VolumeStat.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **c_total** | **float** |  | 
 **c_used** | **float** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VolumeStats.md
+++ b/docs/VolumeStats.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **usage** | [**[VolumeStat]**](VolumeStat.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VolumeStatus.md
+++ b/docs/VolumeStatus.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **lizardfs** | [**VolumeLizardFSStatus**](VolumeLizardFSStatus.md) |  | [optional] 
 **beegfs** | [**VolumeBeeGFSStatus**](VolumeBeeGFSStatus.md) |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/VolumeUpdate.md
+++ b/docs/VolumeUpdate.md
@@ -18,6 +18,6 @@ Name | Type | Description | Notes
 **simulated_quotas** | **bool** |  | [optional] 
 **cloud_account** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkflowTransitionRequest.md
+++ b/docs/WorkflowTransitionRequest.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **directories** | **[int]** |  | [optional] 
 **variables** | **{str: (str, none_type)}** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkflowTransitionResponse.md
+++ b/docs/WorkflowTransitionResponse.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **tasks** | [**[TaskInfo]**](TaskInfo.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Workspace.md
+++ b/docs/Workspace.md
@@ -61,6 +61,6 @@ Name | Type | Description | Notes
 **template** | **int, none_type** |  | [optional] 
 **home_for** | **int, none_type** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkspaceCheckIn.md
+++ b/docs/WorkspaceCheckIn.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **protocol** | **str** |  | [optional] 
 **address** | **str** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkspaceDetail.md
+++ b/docs/WorkspaceDetail.md
@@ -62,6 +62,6 @@ Name | Type | Description | Notes
 **template** | **int, none_type** |  | [optional] 
 **home_for** | **int, none_type** |  | [optional] [readonly] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkspaceDetailPartialUpdate.md
+++ b/docs/WorkspaceDetailPartialUpdate.md
@@ -46,6 +46,6 @@ Name | Type | Description | Notes
 **rw_permission_priority** | **bool** |  | [optional] 
 **template** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkspaceDetailUpdate.md
+++ b/docs/WorkspaceDetailUpdate.md
@@ -46,6 +46,6 @@ Name | Type | Description | Notes
 **rw_permission_priority** | **bool** |  | [optional] 
 **template** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkspaceEndpoint.md
+++ b/docs/WorkspaceEndpoint.md
@@ -13,6 +13,6 @@ Name | Type | Description | Notes
 **username** | **str** |  | 
 **password** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkspaceMini.md
+++ b/docs/WorkspaceMini.md
@@ -8,6 +8,6 @@ Name | Type | Description | Notes
 **name** | **str** |  | [optional] 
 **production** | [**ProductionMini**](ProductionMini.md) |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkspaceMoveToRequest.md
+++ b/docs/WorkspaceMoveToRequest.md
@@ -7,6 +7,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **production** | **int** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkspacePartialUpdate.md
+++ b/docs/WorkspacePartialUpdate.md
@@ -44,6 +44,6 @@ Name | Type | Description | Notes
 **rw_permission_priority** | **bool** |  | [optional] 
 **template** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkspacePermission.md
+++ b/docs/WorkspacePermission.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **group** | **bool, date, datetime, dict, float, int, list, str, none_type** |  | [optional] 
 **read_only** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkspacePermissionPartialUpdate.md
+++ b/docs/WorkspacePermissionPartialUpdate.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **read_only** | **bool** |  | [optional] 
 **workspace** | **int** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkspacePermissionUpdate.md
+++ b/docs/WorkspacePermissionUpdate.md
@@ -10,6 +10,6 @@ Name | Type | Description | Notes
 **group** | **bool, date, datetime, dict, float, int, list, str, none_type** |  | [optional] 
 **read_only** | **bool** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkspaceResolvedPermission.md
+++ b/docs/WorkspaceResolvedPermission.md
@@ -11,6 +11,6 @@ Name | Type | Description | Notes
 **user** | **int, none_type** |  | [optional] 
 **group** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/Workstation.md
+++ b/docs/Workstation.md
@@ -17,6 +17,6 @@ Name | Type | Description | Notes
 **rdc_client_port** | **int, none_type** |  | [optional] 
 **rdc_host_port** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkstationMini.md
+++ b/docs/WorkstationMini.md
@@ -9,6 +9,6 @@ Name | Type | Description | Notes
 **display_name** | **str** |  | [readonly] 
 **hostname** | **str** |  | 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkstationPartialUpdate.md
+++ b/docs/WorkstationPartialUpdate.md
@@ -15,6 +15,6 @@ Name | Type | Description | Notes
 **rdc_client_port** | **int, none_type** |  | [optional] 
 **rdc_host_port** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 

--- a/docs/WorkstationUpdate.md
+++ b/docs/WorkstationUpdate.md
@@ -15,6 +15,6 @@ Name | Type | Description | Notes
 **rdc_client_port** | **int, none_type** |  | [optional] 
 **rdc_host_port** | **int, none_type** |  | [optional] 
 
-[[Back to Model list]](../#documentation-for-models) [[Back to API list]](../#documentation-for-api-endpoints) [[Back to README]](../)
+[[Back to Model list]](../README.md#models) [[Back to API list]](../README.md#api-endpoints) [[Back to README]](../README.md)
 
 


### PR DESCRIPTION
Currently the links from `README.md` below API Endpoints and Models result in a 404. That is because the `*.md` suffix is missing. Also the links back from the pages in `docs/` to `README.md` are broken because `../` is used instead of `../README.md` and the anchors referenced do not exist in `README.md`. This pull request fixes those issues.

Obviously this pull request makes little sense, if you use some internal tooling to build the docs and the rendering of the markdown files is just a side effect of using GitHub.

Cheers